### PR TITLE
Add package-level linting and integration tests.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 lib
 node_modules
 yarn.lock
+test/integration/bower_components

--- a/.npmignore
+++ b/.npmignore
@@ -3,3 +3,4 @@ CHANGELOG.md
 README.md
 node_modules
 test
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,6 @@ language: node_js
 node_js:
   - "4"
   - "6"
+script:
+  - npm test
+  - npm run test:integration || echo '' # Integration test is advisory only.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - Rule that warns about `<style>` tags as direct children of `<dom-module>` tags (rather than being in `<template>` tags).
 - Rule that warns about `is` and `name` attributes on `<dom-module>` tags.
+- APIs for both linting by files and by package.
 
 <!--
 

--- a/package.json
+++ b/package.json
@@ -7,12 +7,13 @@
     "@types/node": "4.0.30",
     "dom5": "^2.0.0",
     "parse5": "^2.2.1",
-    "polymer-analyzer": "^2.0.0-alpha.14",
+    "polymer-analyzer": "^2.0.0-alpha.22",
     "strip-indent": "^2.0.0"
   },
   "devDependencies": {
     "@types/chai": "^3.4.34",
     "@types/mocha": "^2.2.32",
+    "bower": "^1.8.0",
     "chai": "^3.5.0",
     "clang-format": "^1.0.45",
     "mocha": "^3.1.0",
@@ -27,8 +28,9 @@
     "clean": "rm -rf lib; mkdir -p lib",
     "format": "find src | grep '\\.[jt]s$' | xargs clang-format --style=file -i",
     "lint": "tslint -c tslint.json src/*.ts src/**/*.ts",
-    "test": "npm run build && npm run lint && mocha",
-    "test:watch": "watchy -w src/ -- npm test --loglevel=silent"
+    "test": "npm run build && npm run lint && mocha lib/test/**/*.js",
+    "test:watch": "watchy -w src/ -- npm test --loglevel=silent",
+    "test:integration": "npm run build && cd test/integration && bower install --silent && cd ../../ && INTEGRATION_TEST=true mocha lib/test/integration_test.js"
   },
   "repository": {
     "type": "git",

--- a/src/test/all-rules.ts
+++ b/src/test/all-rules.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
+ * Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
  * This code may only be used under the BSD style license found at
  * http://polymer.github.io/LICENSE.txt
  * The complete set of authors may be found at
@@ -12,7 +12,8 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import {MoveStyleIntoTemplate} from './html/move-style-into-template';
-import {Rule} from './rule';
+import {DomModuleNameOrIs} from '../html/dom-module-name-or-is';
+import {MoveStyleIntoTemplate} from '../html/move-style-into-template';
 
-export const AllRules: Rule[] = [new MoveStyleIntoTemplate()];
+// Temporary. To replace with a registry.
+export const AllRules = [new DomModuleNameOrIs(), new MoveStyleIntoTemplate()];

--- a/src/test/integration_test.ts
+++ b/src/test/integration_test.ts
@@ -1,0 +1,103 @@
+/**
+ * @license
+ * Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at
+ * http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at
+ * http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+import {assert} from 'chai';
+import * as path from 'path';
+import {Analyzer} from 'polymer-analyzer';
+import {FSUrlLoader} from 'polymer-analyzer/lib/url-loader/fs-url-loader';
+import {PackageUrlResolver} from 'polymer-analyzer/lib/url-loader/package-url-resolver';
+import {Warning} from 'polymer-analyzer/lib/warning/warning';
+import {WarningPrinter} from 'polymer-analyzer/lib/warning/warning-printer';
+
+import {Linter} from '../linter';
+
+import {AllRules} from './all-rules';
+
+const fixtures_dir = path.resolve(
+    path.join(__dirname, '../../test/integration/bower_components'));
+
+// These tests aren't hermetic, as they depend on a lot of upstream code,
+// so they don't run by default.
+if (process.env['INTEGRATION_TEST']) {
+  suite('integration tests', function() {
+
+    // Analyzing and linting 36MB of code takes longer than 2s.
+    this.timeout(60 * 1000);
+
+    test(`polymer team's elements lint clean`, async() => {
+      const analyzer = new Analyzer({
+        urlLoader: new FSUrlLoader(fixtures_dir),
+        urlResolver: new PackageUrlResolver()
+      });
+      const linter = new Linter(AllRules, analyzer);
+      const warnings = filterWarnings(await linter.lintPackage());
+
+      const counts = new Map<string, number>();
+      for (const warning of warnings) {
+        counts.set(warning.code, (counts.get(warning.code) || 0) + 1);
+      }
+
+      const warningPrinter = new WarningPrinter(
+          process.stdout, {analyzer, color: true, verbosity: 'full'});
+      await warningPrinter.printWarnings(warnings);
+
+      assert.equal(warnings.length, 0, 'Got unexpected warnings');
+    });
+  });
+}
+
+const ignoredCodes = new Set([
+  // We have a few node binary scripts, which start with a shebang.
+  // https://github.com/Polymer/polymer-analyzer/issues/435
+  'parse-error',
+  // We have a lot of references to files which aren't published on bower.
+  // (e.g. demos, tests, dev dependencies, etc).
+  // No current plan to track these down and fix them, as there's just so many.
+  'could-not-load',
+]);
+
+const fileSpecificIgnoredCodes: {[path: string]: Set<string>} = {
+  // https://github.com/PolymerElements/paper-scroll-header-panel/pull/106
+  'paper-scroll-header-panel/demo/lorem-ipsum.html':
+      new Set(['dom-module-invalid-attrs']),
+
+  // https://github.com/PolymerElements/iron-overlay-behavior/pull/228
+  'iron-overlay-behavior/test/test-buttons-wrapper.html':
+      new Set(['style-into-template']),
+
+  // https://github.com/PolymerElements/iron-a11y-keys-behavior/pull/66
+  'iron-a11y-keys-behavior/test/basic-test.html':
+      new Set(['unknown-polymer-behavior']),
+
+  // https://github.com/PolymerLabs/note-app-elements/pull/5
+  'note-app-elements/na-behavior.html': new Set(['unknown-polymer-behavior']),
+
+  // https://github.com/PolymerElements/iron-resizable-behavior/pull/25
+  'iron-resizable-behavior/test/test-elements.html':
+      new Set(['unknown-polymer-behavior']),
+};
+
+// Filter out known issues in the codebase.
+function filterWarnings(warnings: Warning[]) {
+  return warnings.filter(w => {
+    if (ignoredCodes.has(w.code)) {
+      return false;
+    }
+    const fileCodes = fileSpecificIgnoredCodes[w.sourceRange.file] || new Set();
+    if (fileCodes.has(w.code)) {
+      return false;
+    }
+    return true;
+  });
+}

--- a/test/integration/bower.json
+++ b/test/integration/bower.json
@@ -1,0 +1,17 @@
+{
+  "name": "integration",
+  "private": true,
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "test",
+    "tests"
+  ],
+  "dependencies": {
+    "paper-elements": "PolymerElements/paper-elements#^1.0.7",
+    "iron-elements": "PolymerElements/iron-elements#^1.0.10",
+    "app-elements": "PolymerElements/app-elements#^0.10.1",
+    "note-app-elements": "polymerlabs/note-app-elements"
+  }
+}

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,3 +1,2 @@
 --ui tdd
 --require source-map-support/register
-lib/test/**/*.js


### PR DESCRIPTION
Integration tests run all lint passes over all PolymerElements repo's code.

They won't break travis until we can shinkwrap with bower.

<!--
  Thanks for the PR!

  If this change has a user visible change (including
  bug fixes, new features, etc) please describe the change in
  CHANGELOG.md.

  If the change is an entirely package-internal reshuffling/refactoring
  should the change not be described in the CHANGELOG.

  Consider also updating the README.

  More info: http://keepachangelog.com/en/0.3.0/
 -->

 - [x] CHANGELOG.md has been updated

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/polymer/polymer-linter/17)
<!-- Reviewable:end -->
