### PR TITLE
misspelled behaviors rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## Unreleased
 
 ### New Lint Rules
+- `behaviors-spelling`: Warns when the `behaviors` property may not have the American-English spelling
 - `undefined-elements`: Warns when an HTML tag refers to a custom element with no known definition.
 - `unbalanced-polymer-delimiters`: finds unbalanced delimiters in polymer databinding expressions.
 - `unknown-set-attribute`: included in all polymer rule collections.

--- a/src/collections.ts
+++ b/src/collections.ts
@@ -24,6 +24,7 @@ registry.register(
       'undefined-elements',
       'unbalanced-polymer-delimiters',
       'set-unknown-attribute',
+      'behaviors-spelling',
     ]));
 
 registry.register(new RuleCollection(
@@ -37,6 +38,7 @@ Will warn about use of deprecated Polymer 1.x features or brand new features in 
       'undefined-elements',
       'unbalanced-polymer-delimiters',
       'set-unknown-attribute',
+      'behaviors-spelling',
     ]));
 
 registry.register(new RuleCollection(
@@ -49,4 +51,5 @@ For projects that are ready to start transitioning to Polymer 2.0 see polymer-2-
       'undefined-elements',
       'unbalanced-polymer-delimiters',
       'set-unknown-attribute',
+      'behaviors-spelling',
     ]));

--- a/src/polymer/behaviors-spelling.ts
+++ b/src/polymer/behaviors-spelling.ts
@@ -1,0 +1,66 @@
+/**
+ * @license
+ * Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at
+ * http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at
+ * http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+import {Document} from 'polymer-analyzer/lib/model/model';
+
+import stripIndent = require('strip-indent');
+import {Warning, Severity} from 'polymer-analyzer/lib/warning/warning';
+import {stripWhitespace} from '../util';
+import {Rule} from '../rule';
+import {registry} from '../registry';
+
+export class BehaviorsSpelling extends Rule {
+  code = 'behaviors-spelling';
+  description = stripIndent(`
+      Warns when the Polymer \`behaviors\` property is spelled \`behaviours\`,
+      as Polymer uses the American spelling.
+
+          Polymer({
+            behaviours: [...]
+          });
+
+      Accepted syntax:
+
+          Polymer({
+            behaviors: [...]
+          });
+  `).trim();
+
+  constructor() {
+    super();
+  }
+
+  async check(document: Document) {
+    const warnings: Warning[] = [];
+    const elements = document.getByKind('polymer-element');
+
+    for (const element of elements) {
+      const behavioursProperty =
+          element.properties.find((prop) => prop.name === 'behaviours' && !prop.published);
+
+      if (behavioursProperty && behavioursProperty.sourceRange) {
+        warnings.push({
+          code: this.code,
+          message: stripWhitespace(`
+              "behaviours" property should be spelled "behaviors"`),
+          severity: Severity.WARNING,
+          sourceRange: behavioursProperty.sourceRange
+        });
+      }
+    }
+    return warnings;
+  }
+}
+
+registry.register(new BehaviorsSpelling());

--- a/src/rules.ts
+++ b/src/rules.ts
@@ -17,3 +17,4 @@ import './html/move-style-into-template';
 import './html/undefined-elements';
 import './polymer/unbalanced-delimiters';
 import './polymer/set-unknown-attribute';
+import './polymer/behaviors-spelling';

--- a/src/test/polymer/behaviors-spelling_test.ts
+++ b/src/test/polymer/behaviors-spelling_test.ts
@@ -1,0 +1,48 @@
+/**
+ * @license
+ * Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at
+ * http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at
+ * http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+import * as assert from 'assert';
+import * as path from 'path';
+import {Analyzer} from 'polymer-analyzer';
+import {FSUrlLoader} from 'polymer-analyzer/lib/url-loader/fs-url-loader';
+
+import {Linter} from '../../linter';
+import {BehaviorsSpelling} from '../../polymer/behaviors-spelling';
+import {WarningPrettyPrinter} from '../util';
+
+const fixtures_dir = path.resolve(path.join(__dirname, '../../../test'));
+
+suite('BehaviorsSpelling', () => {
+  let analyzer: Analyzer;
+  let warningPrinter: WarningPrettyPrinter;
+  let linter: Linter;
+
+  setup(() => {
+    analyzer = new Analyzer({urlLoader: new FSUrlLoader(fixtures_dir)});
+    warningPrinter = new WarningPrettyPrinter(analyzer);
+    linter = new Linter([new BehaviorsSpelling()], analyzer);
+  });
+
+  test('finds polymer elements with wrong behaviors spelling', async() => {
+    const warnings =
+        await linter.lint(['behaviors-spelling/behaviors-spelling.html']);
+
+    assert.deepEqual(await warningPrinter.prettyPrint(warnings), [`
+    behaviours: []
+    ~~~~~~~~~~~~~~`]);
+    assert.equal(
+        warnings[0].message,
+        '"behaviours" property should be spelled "behaviors"');
+  });
+});

--- a/test/behaviors-spelling/behaviors-spelling.html
+++ b/test/behaviors-spelling/behaviors-spelling.html
@@ -1,0 +1,16 @@
+<!--
+@license
+Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+
+<script>
+  Polymer({
+    is: 'behaviors-spelling',
+    behaviours: []
+  });
+</script>


### PR DESCRIPTION
 - [x] CHANGELOG.md has been updated

There was a PR and issue in the old linter for this. If it seems too trivial/OTT, we can throw it away.

Basically checks for a property named `behaviours` as people often misspell it by accident.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/polymer/polymer-linter/38)
<!-- Reviewable:end -->
