### PR TITLE
Teach the linter dom-repeat's scoped properties.

### DIFF
--- a/src/html/util.ts
+++ b/src/html/util.ts
@@ -93,18 +93,18 @@ export const sharedProperties = new Set([
   'translate',
   'dir',
   'hidden',
-  'tab-index',
-  'access-key',
+  'tabIndex',
+  'accessKey',
   'draggable',
   'spellcheck',
-  'inner-text',
-  'context-menu',
+  'innerText',
   // https://html.spec.whatwg.org/multipage/interaction.html#elementcontenteditable
-  'content-editable',
+  'contentEditable',
+  'isContentEditable',
 
   // https://dom.spec.whatwg.org/#interface-element
   'id',
-  'class-name',
+  'className',
   'slot',
 
 

--- a/src/test/integration_test.ts
+++ b/src/test/integration_test.ts
@@ -128,6 +128,17 @@ const fileSpecificIgnoredCodes: {[path: string]: Set<string>} = {
 
   // This is a template file, and it contains a malformed url.
   'web-component-tester/data/index.html': new Set(['unable-to-analyze']),
+
+  // https://github.com/PolymerElements/paper-dropdown-menu/pull/232
+  'paper-dropdown-menu/paper-dropdown-menu-light.html':
+      new Set(['databind-with-unknown-property']),
+
+  // https://github.com/PolymerElements/paper-input/pull/489
+  'paper-input/paper-input.html': new Set(['databind-with-unknown-property']),
+
+  // https://github.com/PolymerElements/app-layout/pull/426
+  'app-layout/site/device-viewer/device-layout-viewer.html':
+      new Set(['databind-with-unknown-property']),
 };
 
 const codesOkInTestsAndDemos = new Set([

--- a/src/test/polymer/databind-with-unknown-property_test.ts
+++ b/src/test/polymer/databind-with-unknown-property_test.ts
@@ -65,7 +65,10 @@ suite('databind-with-unknown-property', () => {
                ~~~~~~~~~~~~~~~~~~`,
       `
     <div id="{{item}}"></div>
-               ~~~~`
+               ~~~~`,
+      `
+    <div id="{{rabbit}}"></div>
+               ~~~~~~`,
     ]);
 
     assert.deepEqual(warnings.map((w) => w.message), [
@@ -81,7 +84,8 @@ suite('databind-with-unknown-property', () => {
           'be a declared property.',
       'referencedOnlyOnce is not declared or used more than once. ' +
           'Did you mean: translate',
-      'item is not declared or used more than once. Did you mean: title'
+      'item is not declared or used more than once. Did you mean: title',
+      'rabbit is not declared or used more than once. Did you mean: lang',
     ]);
   });
 });

--- a/src/test/polymer/databind-with-unknown-property_test.ts
+++ b/src/test/polymer/databind-with-unknown-property_test.ts
@@ -62,7 +62,10 @@ suite('databind-with-unknown-property', () => {
                ~~~~~~~~~~~~`,
       `
     <div id="{{referencedOnlyOnce}}"></div>
-               ~~~~~~~~~~~~~~~~~~`
+               ~~~~~~~~~~~~~~~~~~`,
+      `
+    <div id="{{item}}"></div>
+               ~~~~`
     ]);
 
     assert.deepEqual(warnings.map((w) => w.message), [
@@ -77,7 +80,8 @@ suite('databind-with-unknown-property', () => {
           'If it\'s part of the element\'s API it should ' +
           'be a declared property.',
       'referencedOnlyOnce is not declared or used more than once. ' +
-          'Did you mean: translate'
+          'Did you mean: translate',
+      'item is not declared or used more than once. Did you mean: title'
     ]);
   });
 });

--- a/test/databind-with-unknown-property/databind-with-unknown-property.html
+++ b/test/databind-with-unknown-property/databind-with-unknown-property.html
@@ -6,6 +6,26 @@
     <div id="{{method(writtenTo)}}"></div>
     <div title="{{title}}"></div>
 
+    <dom-repeat>
+      <template>
+        <div id="{{item}}" title="{{index}}"></div>
+      </template>
+    </dom-repeat>
+
+    <dom-repeat as="smeerp" indexAs="gavagai">
+      <template>
+        <div id="{{smeerp}}" title="{{gavagai}}"></div>
+      </template>
+    </dom-repeat>
+
+    <template is='dom-repeat'>
+      <div id="{{item}}" title="{{index}}"></div>
+    </template>
+
+    <template is='dom-repeat' as="tribble" indexAs="rabbit">
+      <div id="{{tribble}}" title="{{rabbit}}"></div>
+    </template>
+
     <!-- Bad -->
     <div id="{{horse}}"></div>
     <div id="[[onlyReadFrom]]"></div>
@@ -13,6 +33,7 @@
     <nav id="[[onlyReadFrom]]"></nav>
 
     <div id="{{referencedOnlyOnce}}"></div>
+    <div id="{{item}}"></div>
   </template>
   <script>
     Polymer({

--- a/test/databind-with-unknown-property/databind-with-unknown-property.html
+++ b/test/databind-with-unknown-property/databind-with-unknown-property.html
@@ -33,7 +33,10 @@
     <nav id="[[onlyReadFrom]]"></nav>
 
     <div id="{{referencedOnlyOnce}}"></div>
+
+    <!-- The scoped bidirectional bindings above shouldn't count here. -->
     <div id="{{item}}"></div>
+    <div id="{{rabbit}}"></div>
   </template>
   <script>
     Polymer({


### PR DESCRIPTION
Also add a couple more known issues to the integration test's map, and fixup a few entries in our list of known element properties.

 - [X] Bugfix of unreleased feature, no CHANGELOG.md update

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/polymer/polymer-linter/51)
<!-- Reviewable:end -->
