### PR TITLE
Upgrade analyzer to 2.0.0-alpha.41

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "estraverse": "^4.2.0",
     "fast-levenshtein": "^2.0.6",
     "parse5": "^2.2.1",
-    "polymer-analyzer": "2.0.0-alpha.38",
+    "polymer-analyzer": "2.0.0-alpha.40",
     "strip-indent": "^2.0.0"
   },
   "devDependencies": {

--- a/src/polymer/call-super-in-callbacks.ts
+++ b/src/polymer/call-super-in-callbacks.ts
@@ -39,9 +39,10 @@ class CallSuperInCallbacks extends Rule {
   async check(document: Document) {
     const warnings: Warning[] = [];
 
-    const elementLikes =
-        Array.from(document.getFeatures({kind: 'element'}))
-            .concat(Array.from(document.getFeatures({kind: 'element-mixin'})));
+    const elementLikes = new Array<Element|ElementMixin>(
+        ...document.getFeatures({kind: 'element'}),
+        ...document.getFeatures({kind: 'element-mixin'}));
+
     for (const elementLike of elementLikes) {
       // TODO(rictic): methods should have astNodes, that would make this
       //     simpler. Filed as:
@@ -159,8 +160,8 @@ function getClassBody(astNode?: estree.Node|null): undefined|estree.ClassBody {
  * super[methodName]() be called. Returns undefined if no such class exists.
  */
 function mustCallSuper(
-    elementLike: Element, methodName: string, document: Document): (string|
-                                                                    undefined) {
+    elementLike: Element|ElementMixin, methodName: string, document: Document):
+    (string|undefined) {
   // TODO(rictic): look up the inheritance graph for a jsdoc tag that describes
   //     the method as needing to be called?
   if (!methodsThatMustCallSuper.has(methodName)) {


### PR DESCRIPTION
Attempted to upgrade analyzer to 2.0.0-alpha.40

There was one area where typings had to be corrected, which was in `src/polymer/call-super-in-callbacks.ts`.  My attempted correction produced a single failing test.

However, I'm not sure I understand whether this failure is a result of analyzer knowing more than it did before and therefore the test needs to just be updated or whether there's a new problem.

```
  34 passing (380ms)
  1 failing

  1) call-super-in-callbacks warns for the proper cases and with the right messages:

      AssertionError: expected [ Array(24) ] to deeply equal [ Array(9) ]
      + expected - actual

       [
      -  "\n    connectedCallback() {\n    ~~~~~~~~~~~~~~~~~~~~~\n      super.connectedCallback();\n~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\n      this.appendChild(document.createElement('lol'));\n~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
~~~~~~~~~~\n    }\n~~~~~"
      -  "\n    disconnectedCallback() {\n    ~~~~~~~~~~~~~~~~~~~~~~~~\n      super.disconnectedCallback();\n~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\n    }\n~~~~~"
      -  "\n    attributeChangedCallback() {\n    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~\n      super.attributeChangedCallback();\n~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\n    }\n~~~~~"
      -  "\n    connectedCallback() {\n    ~~~~~~~~~~~~~~~~~~~~~\n      super.connectedCallback();\n~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\n    }\n~~~~~"
      -  "\n    connectedCallback() {\n    ~~~~~~~~~~~~~~~~~~~~~\n      super.connectedCallback();\n~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\n    }\n~~~~~"
      -  "\n    connectedCallback() {\n    ~~~~~~~~~~~~~~~~~~~~~\n      super.connectedCallback();\n~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\n    }\n~~~~~"
      -  "\n    disconnectedCallback() {\n    ~~~~~~~~~~~~~~~~~~~~~~~~\n      super.disconnectedCallback();\n~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\n    }\n~~~~~"
      -  "\n    connectedCallback() { /* BadSuper */ }\n    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
      -  "\n    disconnectedCallback() {/* BadSuper */ }\n    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
      -  "\n    attributeChangedCallback() {/* BadSuper */ }\n    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
      -  "\n    connectedCallback() { /* ReassignedBad */ }\n    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
      -  "\n    connectedCallback() { /* BadMixin1 */ }\n    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
      -  "\n    connectedCallback() { /* BadMixin2 */ }\n    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
      -  "\n    disconnectedCallback() { /* BadMixin2 */ }\n    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
      -  "\n    connectedCallback() { }\n    ~~~~~~~~~~~~~~~~~~~~~~~"
         "\n    constructor() {/* BadSuper */ }\n    ~~~~~~~~~~~"
         "\n    connectedCallback() { /* BadSuper */ }\n    ~~~~~~~~~~~~~~~~~"
         "\n    disconnectedCallback() {/* BadSuper */ }\n    ~~~~~~~~~~~~~~~~~~~~"
         "\n    attributeChangedCallback() {/* BadSuper */ }\n    ~~~~~~~~~~~~~~~~~~~~~~~~"

      at Function.assert.deepEqual (node_modules/chai/lib/chai/interface/assert.js:216:32)
      at Object.<anonymous> (lib/test/polymer/call-super-in-callbacks_test.js:51:23)
      at next (native)
      at fulfilled (lib/test/polymer/call-super-in-callbacks_test.js:17:58)
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/polymer/polymer-linter/79)
<!-- Reviewable:end -->
