### PR TITLE
Update analyzer to 2.0.0 alpha.41

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-<!--## Unreleased-->
+## Unreleased
+
+- Upgraded dependency `polymer-analyzer` to 2.0.0-alpha.41, providing better method privacy inference, support for new JSDoc tags including those in HTML comments for custom elements, and better warnings for mixins, elements, and classes.
 
 ## [2.0.0] - 2017-04-14
 

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "estraverse": "^4.2.0",
     "fast-levenshtein": "^2.0.6",
     "parse5": "^2.2.1",
-    "polymer-analyzer": "2.0.0-alpha.38",
+    "polymer-analyzer": "2.0.0-alpha.41",
     "strip-indent": "^2.0.0"
   },
   "devDependencies": {

--- a/src/polymer/call-super-in-callbacks.ts
+++ b/src/polymer/call-super-in-callbacks.ts
@@ -39,9 +39,10 @@ class CallSuperInCallbacks extends Rule {
   async check(document: Document) {
     const warnings: Warning[] = [];
 
-    const elementLikes =
-        Array.from(document.getFeatures({kind: 'element'}))
-            .concat(Array.from(document.getFeatures({kind: 'element-mixin'})));
+    const elementLikes = new Array<Element|ElementMixin>(
+        ...document.getFeatures({kind: 'element'}),
+        ...document.getFeatures({kind: 'element-mixin'}));
+
     for (const elementLike of elementLikes) {
       // TODO(rictic): methods should have astNodes, that would make this
       //     simpler. Filed as:
@@ -159,8 +160,8 @@ function getClassBody(astNode?: estree.Node|null): undefined|estree.ClassBody {
  * super[methodName]() be called. Returns undefined if no such class exists.
  */
 function mustCallSuper(
-    elementLike: Element, methodName: string, document: Document): (string|
-                                                                    undefined) {
+    elementLike: Element|ElementMixin, methodName: string, document: Document):
+    (string|undefined) {
   // TODO(rictic): look up the inheritance graph for a jsdoc tag that describes
   //     the method as needing to be called?
   if (!methodsThatMustCallSuper.has(methodName)) {


### PR DESCRIPTION
 - Essentially a straightforward update to latest analyzer with a couple type changes in the `call-super-in-callbacks` `mustCallSuper()` signature. 
 - [x] CHANGELOG.md has been updated

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/polymer/polymer-linter/81)
<!-- Reviewable:end -->
