### PR TITLE
Add support for polymer lint directives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+- Add support for linting `polymer-lint enable` & `polymer-lint disable` comment directives.
 
 ## [2.0.1] - 2017-05-09
 

--- a/src/linter.ts
+++ b/src/linter.ts
@@ -40,7 +40,7 @@ function filterDirectivesByCode(
  * will be filtered out as invalid.
  *
  * TODO(fks) 05-10-2017: Improve performance by first sorting warnings, and then
- * stepping through warnings and directives in tandem in a single pass.
+ * stepping through warnings and directives in lockstep in a single pass.
  */
 function filterLintWarningsByDirective(
     warnings: Warning[], directives: Set<PolymerLintDirective>) {

--- a/src/test/linter_test.ts
+++ b/src/test/linter_test.ts
@@ -17,6 +17,7 @@ import * as path from 'path';
 import {Analyzer, Document, FSUrlLoader, Severity, Warning} from 'polymer-analyzer';
 
 import {Linter} from '../linter';
+import {registry} from '../registry';
 import {Rule} from '../rule';
 
 import {WarningPrettyPrinter} from './util';
@@ -104,6 +105,102 @@ suite('Linter', () => {
         'bower_components/external.html',
         'bower_components/external.html'
       ].sort());
+    });
+
+    suite('comment directives', () => {
+
+      (<[[string, any]]>[
+        ['comment-directives/disable-all.html', []],
+        [
+          'comment-directives/disable-one.html',
+          [{
+            code: 'behaviors-spelling',
+            sourceRange: {
+              file: 'comment-directives/disable-one.html',
+              start: {line: 8, column: 4},
+              end: {line: 8, column: 18}
+            }
+          }]
+        ],
+        [
+          'comment-directives/disable-all-then-renable-one.html',
+          [{
+            code: 'dom-module-invalid-attrs',
+            sourceRange: {
+              file: 'comment-directives/disable-all-then-renable-one.html',
+              start: {line: 4, column: 12},
+              end: {line: 4, column: 16}
+            }
+          }]
+        ],
+        [
+          'comment-directives/disable-all-then-renable-all.html',
+          [{
+            code: 'dom-module-invalid-attrs',
+            sourceRange: {
+              file: 'comment-directives/disable-all-then-renable-all.html',
+              start: {line: 4, column: 12},
+              end: {line: 4, column: 16}
+            }
+          }]
+
+        ],
+        [
+          'comment-directives/disable-one-then-renable-one.html',
+          [{
+            code: 'dom-module-invalid-attrs',
+            sourceRange: {
+              file: 'comment-directives/disable-one-then-renable-one.html',
+              start: {line: 4, column: 12},
+              end: {line: 4, column: 16}
+            }
+          }]
+        ],
+        [
+          'comment-directives/disable-one-then-renable-all.html',
+          [{
+            code: 'dom-module-invalid-attrs',
+            sourceRange: {
+              file: 'comment-directives/disable-one-then-renable-all.html',
+              start: {line: 4, column: 12},
+              end: {line: 4, column: 16}
+            }
+          }]
+        ],
+        ['comment-directives/inline-documents-inherit.html', []],
+        [
+          'comment-directives/inline-documents-interweave.html',
+          [
+            {
+              code: 'dom-module-invalid-attrs',
+              sourceRange: {
+                file: 'comment-directives/inline-documents-interweave.html',
+                start: {line: 23, column: 12},
+                end: {line: 23, column: 16}
+              }
+            },
+            {
+              code: 'behaviors-spelling',
+              sourceRange: {
+                file: 'comment-directives/inline-documents-interweave.html',
+                start: {line: 17, column: 4},
+                end: {line: 17, column: 18}
+              }
+            }
+          ]
+        ],
+      ]).forEach(([filePath, expectedResults]) => {
+        test(`properly lints ${filePath}`, async() => {
+          const linter = new Linter(
+              registry.getRules(
+                  ['dom-module-invalid-attrs', 'behaviors-spelling']),
+              analyzer);
+          const warnings = await linter.lint([filePath]);
+          const warningsData =
+              warnings.map(({code, sourceRange}) => ({code, sourceRange}));
+          assert.deepEqual(warningsData, expectedResults);
+        });
+      });
     });
   });
 });

--- a/test/comment-directives/disable-all-then-renable-all.html
+++ b/test/comment-directives/disable-all-then-renable-all.html
@@ -1,0 +1,6 @@
+<!-- polymer-lint disable -->
+<dom-module name="baz-elem">
+</dom-module>
+<!-- polymer-lint enable -->
+<dom-module name="baz-elem">
+</dom-module>

--- a/test/comment-directives/disable-all-then-renable-one.html
+++ b/test/comment-directives/disable-all-then-renable-one.html
@@ -1,0 +1,6 @@
+<!-- polymer-lint disable -->
+<dom-module name="baz-elem">
+</dom-module>
+<!-- polymer-lint enable: dom-module-invalid-attrs -->
+<dom-module name="baz-elem">
+</dom-module>

--- a/test/comment-directives/disable-all.html
+++ b/test/comment-directives/disable-all.html
@@ -1,0 +1,12 @@
+<!-- polymer-lint disable -->
+
+<!-- this node's warning should not be reported -->
+<dom-module name="baz-elem"></dom-module>
+
+<!-- this node's warning should not be reported -->
+<script>
+  Polymer({
+    behaviours: []
+  });
+
+</script>

--- a/test/comment-directives/disable-one-then-renable-all.html
+++ b/test/comment-directives/disable-one-then-renable-all.html
@@ -1,0 +1,6 @@
+<!-- polymer-lint disable: dom-module-invalid-attrs -->
+<dom-module name="baz-elem">
+</dom-module>
+<!-- polymer-lint enable -->
+<dom-module name="baz-elem">
+</dom-module>

--- a/test/comment-directives/disable-one-then-renable-one.html
+++ b/test/comment-directives/disable-one-then-renable-one.html
@@ -1,0 +1,6 @@
+<!-- polymer-lint disable: dom-module-invalid-attrs -->
+<dom-module name="baz-elem">
+</dom-module>
+<!-- polymer-lint enable: dom-module-invalid-attrs -->
+<dom-module name="baz-elem">
+</dom-module>

--- a/test/comment-directives/disable-one.html
+++ b/test/comment-directives/disable-one.html
@@ -1,0 +1,12 @@
+<!-- polymer-lint disable: dom-module-invalid-attrs -->
+
+<!-- this node's warning should not be reported -->
+<dom-module name="baz-elem"></dom-module>
+
+<!-- this node's warning should be reported -->
+<script>
+  Polymer({
+    behaviours: []
+  });
+
+</script>

--- a/test/comment-directives/inline-documents-inherit.html
+++ b/test/comment-directives/inline-documents-inherit.html
@@ -1,0 +1,10 @@
+<!-- polymer-lint disable -->
+<dom-module name="baz-elem"></dom-module>
+
+<!-- Warnings inside of this inline document should also be disabled -->
+<script>
+  Polymer({
+    behaviours: []
+  });
+
+</script>

--- a/test/comment-directives/inline-documents-interweave.html
+++ b/test/comment-directives/inline-documents-interweave.html
@@ -1,0 +1,24 @@
+<!-- polymer-lint disable -->
+
+<!-- this node's warning should not be reported -->
+<dom-module name="foo-elem"></dom-module>
+
+<script>
+  Polymer({
+    is: 'foo-element',
+    // This warning should not be reported
+    behaviours: []
+  });
+
+  /* polymer-lint enable */
+
+  Polymer({
+    is: 'bar-element',
+    // This warning should be reported
+    behaviours: []
+  });
+
+</script>
+
+<!-- this node's warning should be reported -->
+<dom-module name="bar-elem"></dom-module>


### PR DESCRIPTION
 - [X] CHANGELOG.md has been updated
- Based on https://github.com/Polymer/polymer-analyzer/pull/672, ***needed before tests will pass***

#### Features supported
- disable (and later enable, potentially) all provided rules in a file 
- disable (and later enable, potentially) specific provided rules in a file
- honor directive sourceRange order in a file, even across parent/inlined documents

#### Features not yet supported
- enable a rule that was not specified to the linter at creation. Ex: can't enable rules not mentioned in rule set. (Would need a bigger refactor of how the linter works, not blocked to tackle incrementally in a future PR)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/polymer/polymer-linter/85)
<!-- Reviewable:end -->
