### PR TITLE
Respect index-as attribute in dom-repeat

### DIFF
--- a/src/polymer/databind-with-unknown-property.ts
+++ b/src/polymer/databind-with-unknown-property.ts
@@ -60,7 +60,9 @@ class DatabindWithUnknownProperty extends HtmlRule {
         const scope = parsedDocument.sourceRangeForNode(domRepeat)!;
         const itemProperty = dom5.getAttribute(domRepeat, 'as') || 'item';
         const indexProperty =
-            dom5.getAttribute(domRepeat, 'indexAs') || 'index';
+            dom5.getAttribute(domRepeat, 'index-as') ||
+            dom5.getAttribute(domRepeat, 'indexAs') ||
+            'index';
         scopedProperties.push({scope, property: itemProperty});
         scopedProperties.push({scope, property: indexProperty});
       }

--- a/test/databind-with-unknown-property/databind-with-unknown-property.html
+++ b/test/databind-with-unknown-property/databind-with-unknown-property.html
@@ -12,6 +12,12 @@
       </template>
     </dom-repeat>
 
+    <dom-repeat as="smeerp" index-as="gavagai">
+      <template>
+        <div id="{{smeerp}}" title="{{gavagai}}"></div>
+      </template>
+    </dom-repeat>
+
     <dom-repeat as="smeerp" indexAs="gavagai">
       <template>
         <div id="{{smeerp}}" title="{{gavagai}}"></div>
@@ -20,6 +26,10 @@
 
     <template is='dom-repeat'>
       <div id="{{item}}" title="{{index}}"></div>
+    </template>
+
+    <template is='dom-repeat' as="tribble" index-as="rabbit">
+      <div id="{{tribble}}" title="{{rabbit}}"></div>
     </template>
 
     <template is='dom-repeat' as="tribble" indexAs="rabbit">


### PR DESCRIPTION
Some projects use hyphenated attribute names instead of camelCase.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/polymer/polymer-linter/102)
<!-- Reviewable:end -->
