### PR TITLE
iron-flex-layout-import and iron-flex-layout-classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,10 +13,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Support warning about and automatically fixing element declarations that use `<content>` to use `<slot>` instead. This is a breaking change to an element,
 so it is not on by default.
   - It automatically adds the `old-content-selector` attribute to migrated `<slot>` elements, so uses can be automatically upgraded as well.
-- Support fixable warning about usage of deprecated `iron-flex-layout/classes/*.html` files via the new rule `iron-flex-layout-import`
-  - It automatically upgrades to import instead the `iron-flex-layout/iron-flex-layout-classes.html`
-- Support fixable warning about usage of iron-flex-layout classes without including the required style modules via the new rule `iron-flex-layout-classes`
-  - It automatically upgrades the element shadow root to include the iron-flex-layout style modules.
+- Support warning about and fixing usage of deprecated `iron-flex-layout/classes/*.html` files via the new rule `iron-flex-layout-import`
+  - It automatically upgrades to import the `iron-flex-layout/iron-flex-layout-classes.html` instead.
+- Support warning about and fixing usage of iron-flex-layout classes without including the required style modules via the new rule `iron-flex-layout-classes`
+  - It automatically upgrades the element template to include the iron-flex-layout style modules.
 
 ## [2.1.0] - 2017-10-13
 - Warn for old-style @apply without parentheses, and var() with a fallback value of a bare css variable.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 so it is not on by default.
   - It automatically adds the `old-content-selector` attribute to migrated `<slot>` elements, so uses can be automatically upgraded as well.
 - Support automatic fixing of the warning where a `<style>` element is a direct child of a dom-module's `<template>`.
-- Support warning about and fixing usage of deprecated `iron-flex-layout/classes/*.html` files via the new rule `iron-flex-layout-import`
-  - It automatically upgrades to import the `iron-flex-layout/iron-flex-layout-classes.html` instead.
+- Support warning about and fixing usage of deprecated `iron-flex-layout/classes/*` files via the new rule `iron-flex-layout-import`
+  - It automatically adds, updates, or deletes the import `iron-flex-layout/iron-flex-layout-classes.html`.
 - Support warning about and fixing usage of iron-flex-layout classes without including the required style modules via the new rule `iron-flex-layout-classes`
   - It automatically upgrades the element template to include the iron-flex-layout style modules.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Support warning about and automatically fixing element declarations that use `<content>` to use `<slot>` instead. This is a breaking change to an element,
 so it is not on by default.
   - It automatically adds the `old-content-selector` attribute to migrated `<slot>` elements, so uses can be automatically upgraded as well.
+- Support fixable warning about usage of deprecated `iron-flex-layout/classes/*.html` files via the new rule `iron-flex-layout-import`
+  - It automatically upgrades to import instead the `iron-flex-layout/iron-flex-layout-classes.html`
+- Support fixable warning about usage of iron-flex-layout classes without including the required style modules via the new rule `iron-flex-layout-classes`
+  - It automatically upgrades the element shadow root to include the iron-flex-layout style modules.
 
 ## [2.1.0] - 2017-10-13
 - Warn for old-style @apply without parentheses, and var() with a fallback value of a bare css variable.

--- a/src/html/move-style-into-template.ts
+++ b/src/html/move-style-into-template.ts
@@ -15,13 +15,13 @@
 import * as clone from 'clone';
 import * as dom5 from 'dom5';
 import * as parse5 from 'parse5';
-import {Document, ParsedHtmlDocument, Severity, SourceRange} from 'polymer-analyzer';
+import {Document, ParsedHtmlDocument, Severity} from 'polymer-analyzer';
 
 import {registry} from '../registry';
 import {FixableWarning, Replacement} from '../warning';
 
 import {HtmlRule} from './rule';
-import {addIndentation, getIndentationInside} from './util';
+import {addIndentation, getIndentationInside, removeTrailingWhitespace} from './util';
 
 import stripIndent = require('strip-indent');
 
@@ -164,27 +164,6 @@ class MoveStyleIntoTemplate extends HtmlRule {
     // styles into the template we preserve their order.
     return warnings.reverse();
   }
-}
-
-function removeTrailingWhitespace(
-    textNode: dom5.Node, parsedDocument: ParsedHtmlDocument) {
-  const prevText = dom5.getTextContent(textNode);
-  const match = prevText.match(/\n?[ \t]+$/);
-  if (!match) {
-    return;
-  }
-  const range = parsedDocument.sourceRangeForNode(textNode)!;
-  const lengthOfPreviousLine =
-      parsedDocument.newlineIndexes[range.end.line - 1] -
-      (parsedDocument.newlineIndexes[range.end.line - 2] || -1) - 1;
-  const newRange: SourceRange = {
-    ...range,
-    start: {
-      column: lengthOfPreviousLine,
-      line: range.end.line - 1,
-    }
-  };
-  return {range: newRange, replacementText: ''};
 }
 
 registry.register(new MoveStyleIntoTemplate());

--- a/src/html/util.ts
+++ b/src/html/util.ts
@@ -114,6 +114,7 @@ export const sharedProperties = new Set([
   'is',
 ]);
 
+/**
  * If the given node is a text node, add the given addition indentation to
  * each line of its contents.
  */

--- a/src/html/util.ts
+++ b/src/html/util.ts
@@ -12,6 +12,9 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
+import * as dom5 from 'dom5';
+import cssWhat = require('css-what');
+
 // Attributes that are on every HTMLElement.
 export const sharedAttributes = new Set([
   // From https://html.spec.whatwg.org/multipage/dom.html#htmlelement
@@ -110,3 +113,74 @@ export const sharedProperties = new Set([
 
   'is',
 ]);
+
+/**
+ * Converts a css selector into a dom5 predicate.
+ *
+ * This is intended for handling only selectors that match an individual element
+ * in isolation, it does throws if the selector talks about relationships
+ * between elements like `.foo .bar` or `.foo > .bar`.
+ */
+export function elementSelectorToPredicate(simpleSelector: string):
+    dom5.Predicate {
+  const parsed = cssWhat(simpleSelector);
+  // The output of cssWhat is two levels of arrays. The outer level are any
+  // selectors joined with a comma, so it matches if any of the inner selectors
+  // match. The inner array are simple selectors like `.foo` and `#bar` which
+  // must all match.
+  return dom5.predicates.OR(...parsed.map((simpleSelectors) => {
+    return dom5.predicates.AND(
+        ...simpleSelectors.map(simpleSelectorToPredicate));
+  }));
+}
+
+function simpleSelectorToPredicate(selector: cssWhat.Simple) {
+  switch (selector.type) {
+    case 'adjacent':
+    case 'child':
+    case 'descendant':
+    case 'parent':
+    case 'sibling':
+    case 'pseudo':
+      throw new Error(`Unsupported CSS operator: ${selector.type}`);
+    case 'attribute':
+      return attributeSelectorToPredicate(selector);
+    case 'tag':
+      return dom5.predicates.hasTagName(selector.name);
+    case 'universal':
+      return () => true;
+  }
+  const never: never = selector;
+  throw new Error(`Unexpected node type from css parser: ${never}`);
+}
+
+function attributeSelectorToPredicate(selector: cssWhat.Attribute):
+    dom5.Predicate {
+  switch (selector.action) {
+    case 'exists':
+      return dom5.predicates.hasAttr(selector.name);
+    case 'equals':
+      return dom5.predicates.hasAttrValue(selector.name, selector.value);
+    case 'start':
+      return (el) => {
+        const attrValue = dom5.getAttribute(el, selector.name);
+        return attrValue != null && attrValue.startsWith(selector.value);
+      };
+    case 'end':
+      return (el) => {
+        const attrValue = dom5.getAttribute(el, selector.name);
+        return attrValue != null && attrValue.endsWith(selector.value);
+      };
+    case 'element':
+      return dom5.predicates.hasSpaceSeparatedAttrValue(
+          selector.name, selector.value);
+    case 'any':
+      return (el) => {
+        const attrValue = dom5.getAttribute(el, selector.name);
+        return attrValue != null && attrValue.includes(selector.value);
+      };
+  }
+  const never: never = selector.action;
+  throw new Error(
+      `Unexpected type of attribute matcher from CSS parser ${never}`);
+}

--- a/src/html/util.ts
+++ b/src/html/util.ts
@@ -184,3 +184,41 @@ function attributeSelectorToPredicate(selector: cssWhat.Attribute):
   throw new Error(
       `Unexpected type of attribute matcher from CSS parser ${never}`);
 }
+
+/**
+ * Estimates the leading indentation of direct children inside the given node.
+ *
+ * Assumes that the given element is written in one of these styles:
+ *   <foo>
+ *   </foo>
+ *
+ *   <foo>
+ *     <bar></bar>
+ *   </foo>
+ *
+ * And not like:
+ *   <foo><bar></bar></bar>
+ */
+export function getIndentationInside(parentNode: dom5.Node) {
+  if (!parentNode.childNodes || parentNode.childNodes.length === 0) {
+    return '';
+  }
+  const firstChild = parentNode.childNodes[0];
+  if (!dom5.isTextNode(firstChild)) {
+    return '';
+  }
+  const text = dom5.getTextContent(firstChild);
+  const match = text.match(/(^|\n)([ \t]+)/);
+  if (!match) {
+    return '';
+  }
+  // If the it's an empty node with just one line of whitespace, like this:
+  //     <div>
+  //     </div>
+  // Then the indentation of actual content inside is one level deeper than
+  // the whitespace on that second line.
+  if (parentNode.childNodes.length === 1 && text.match(/^\n[ \t]+$/)) {
+    return match[2] + '  ';
+  }
+  return match[2];
+}

--- a/src/polymer/elements/iron-flex-layout-classes.ts
+++ b/src/polymer/elements/iron-flex-layout-classes.ts
@@ -16,13 +16,13 @@ import * as dom5 from 'dom5';
 import {treeAdapters} from 'parse5';
 import {Document, ParsedHtmlDocument, Severity} from 'polymer-analyzer';
 
-import {HtmlRule} from '../html/rule';
-import {registry} from '../registry';
-import {FixableWarning} from '../warning';
+import {HtmlRule} from '../../html/rule';
+import {registry} from '../../registry';
+import {FixableWarning} from '../../warning';
 
 import stripIndent = require('strip-indent');
 
-import {elementSelectorToPredicate, getIndentationInside, addAttribute, prependContentInto} from '../html/util';
+import {elementSelectorToPredicate, getIndentationInside, addAttribute, prependContentInto} from '../../html/util';
 
 const p = dom5.predicates;
 

--- a/src/polymer/elements/iron-flex-layout-import.ts
+++ b/src/polymer/elements/iron-flex-layout-import.ts
@@ -25,7 +25,7 @@ import stripIndent = require('strip-indent');
 // Capture any import file in the `classes` folder.
 const deprecatedImports = /iron-flex-layout\/classes\/.*/;
 const replacementImport = 'iron-flex-layout/iron-flex-layout-classes.html';
-const polymerLikeImport = /(iron|paper|app)-.*\/(iron|paper|app)-.*.html/;
+const polymerLikeImport = /(iron|paper|app)-.*\/(iron|paper|app)-.*\.html$/;
 
 const p = dom5.predicates;
 

--- a/src/polymer/elements/rules.ts
+++ b/src/polymer/elements/rules.ts
@@ -1,0 +1,16 @@
+/**
+ * @license
+ * Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at
+ * http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at
+ * http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+import './iron-flex-layout-classes';
+import './iron-flex-layout-import';

--- a/src/polymer/iron-flex-layout-classes.ts
+++ b/src/polymer/iron-flex-layout-classes.ts
@@ -64,6 +64,8 @@ const styleModules = [
   }
 ];
 
+const isStyleInclude = p.AND(p.hasTagName('style'), p.hasAttr('include'));
+
 class IronFlexLayoutClasses extends HtmlRule {
   code = 'iron-flex-layout-classes';
   description = stripIndent(`
@@ -147,11 +149,11 @@ function getMissingStyleModules(node: dom5.Node) {
   if (!usedModules.length) {
     return;
   }
-  const styleNodes = dom5.queryAll(node, p.hasTagName('style'));
+  const styleNodes = dom5.queryAll(node, isStyleInclude);
   let currentModules: string[] = [];
   for (const style of styleNodes) {
-    const include = dom5.getAttribute(style, 'include') || '';
-    currentModules = [...currentModules, ...include.split(' ')];
+    currentModules =
+        [...currentModules, ...dom5.getAttribute(style, 'include')!.split(' ')];
   }
   const missingModules =
       usedModules.filter((m) => currentModules.indexOf(m) === -1);

--- a/src/polymer/iron-flex-layout-classes.ts
+++ b/src/polymer/iron-flex-layout-classes.ts
@@ -1,0 +1,271 @@
+/**
+ * @license
+ * Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at
+ * http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at
+ * http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+import * as dom5 from 'dom5';
+import {treeAdapters} from 'parse5';
+import {Document, ParsedHtmlDocument, Severity} from 'polymer-analyzer';
+
+import {HtmlRule} from '../html/rule';
+import {registry} from '../registry';
+import {FixableWarning} from '../warning';
+
+import stripIndent = require('strip-indent');
+
+import cssWhat = require('css-what');
+
+const p = dom5.predicates;
+
+const deprecatedImport = 'iron-flex-layout/classes/iron-flex-layout.html';
+const replacementImport = 'iron-flex-layout/iron-flex-layout-classes.html';
+
+const validModules = {
+  'iron-flex': elementSelectorToPredicate('.layout.horizontal, .layout.vertical, .layout.inline, .layout.wrap, .layout.no-wrap, .layout.center, .layout.center-center, .layout.center-justified, .flex, .flex-auto, .flex-none'),
+  'iron-flex-reverse': elementSelectorToPredicate('.layout.horizontal-reverse, .layout.vertical-reverse, .layout.wrap-reverse'),
+  'iron-flex-alignment': elementSelectorToPredicate('.layout.start, .layout.center, .layout.center-center, .layout.end, .layout.baseline, .layout.start-justified, .layout.center-justified, .layout.center-center, .layout.end-justified, .layout.around-justified, .layout.justified, .self-start, .self-center, .self-end, .self-stretch, .self-baseline, .layout.start-aligned, .layout.end-aligned, .layout.center-aligned, .layout.between-aligned, .layout.around-aligned'),
+  'iron-flex-factors': elementSelectorToPredicate('.flex-1, .flex-2, .flex-3, .flex-4, .flex-5, .flex-6, .flex-7, .flex-8, .flex-9, .flex-10, .flex-11, .flex-12'),
+  'iron-positioning': elementSelectorToPredicate('.block, [hidden], .invisible, .relative, .fit, body.fullbleed, .scroll, .fixed-bottom, .fixed-left, .fixed-top, .fixed-right'),
+};
+const flexLayoutClassesSelector = p.OR(...Object.values(validModules));
+const flexLayoutModules = 'iron-flex iron-flex-reverse iron-flex-alignment iron-flex-factors iron-positioning';
+
+
+class IronFlexLayoutClasses extends HtmlRule {
+  code = 'iron-flex-layout-classes';
+  description = stripIndent(`
+      Warns when classes/iron-flex-layout.html is not needed.
+  `).trim();
+
+  async checkDocument(parsedDocument: ParsedHtmlDocument, document: Document) {
+    const warnings: FixableWarning[] = [];
+
+    // 1. replace import classes/iron-(shadow-)flex-layout.html with iron-flex-layout.html
+    // 2. check if uses any of the style classes
+    this.convertDeclarations(parsedDocument, document, warnings);
+
+    return warnings;
+  }
+
+  convertDeclarations(
+      parsedDocument: ParsedHtmlDocument, document: Document,
+      warnings: FixableWarning[]) {
+    const imports = document.getFeatures({ kind: 'import' });
+    for (const imp of imports) {
+      const node = imp.astNode;
+      // 1. look if it imports classes/iron-flex-layout.html
+      const href = dom5.getAttribute(node, 'href');
+      if (!href || !href.endsWith(deprecatedImport)) {
+        continue;
+      }
+      // 2. look if it uses the classes in the template.
+      const hrefRange = parsedDocument.sourceRangeForAttributeValue(node, 'href')!;
+      const modules = modulesUsingFlexLayoutClasses(document);
+      if (modules.length) {
+        // Replace import with the correct one.
+        const fix = [];
+        fix.push({
+          // excludeQuotes = true returns a range that is 1 index too big, so include the quotes
+          // in the range and in the replacement text.
+          replacementText: `"${href.replace(deprecatedImport, replacementImport)}"`,
+          range: hrefRange
+        });
+        // Update style include for each module
+        for (const domModule of modules) {
+          const template = dom5.query(domModule, p.hasTagName('template'))!;
+          let styleNode = dom5.query(
+            treeAdapters.default.getTemplateContent(template),
+            p.hasTagName('style'));
+          if (styleNode) {
+            if (dom5.hasAttribute(styleNode, 'include')) {
+              const includesAttr = dom5.getAttribute(styleNode, 'include')!;
+              fix.push({
+                replacementText: `"${includesAttr} ${flexLayoutModules}"`,
+                range: parsedDocument.sourceRangeForAttributeValue(styleNode, 'include')!
+              });
+            } else {
+              const tagRange = parsedDocument.sourceRangeForStartTag(styleNode)!;
+              fix.push({
+                replacementText: ` include="${flexLayoutModules}"`,
+                range: {
+                  file: tagRange.file,
+                  start: { line: tagRange.end.line, column: tagRange.end.column - 1 },
+                  end: { line: tagRange.end.line, column: tagRange.end.column - 1 }
+                }
+              });
+            }
+          } else {
+            const tagRange = parsedDocument.sourceRangeForStartTag(template)!;
+            // TODO(valdrin): indent properly would be nice...
+            fix.push({
+              replacementText: `\n<style include="${flexLayoutModules}"></style>`,
+              range: {
+                file: tagRange.file,
+                start: { line: tagRange.end.line, column: tagRange.end.column },
+                end: { line: tagRange.end.line, column: tagRange.end.column }
+              }
+            });
+          }
+        }
+        // TODO(valdrin) go through all the dependencies to see if they need the same fixes.
+        const warning = new FixableWarning({
+          code: 'iron-flex-layout-classes',
+          message:
+              `${deprecatedImport} import is deprecated. ` +
+              `Replace with ${replacementImport} import.`,
+          parsedDocument,
+          severity: Severity.WARNING,
+          sourceRange: hrefRange
+        });
+        warning.fix = fix;
+        warnings.push(warning);
+      } else {
+        // Suggest to remove the import as it's not used.
+        const warning = new FixableWarning({
+          code: 'iron-flex-layout-classes',
+          message:
+              `Remove ${deprecatedImport} import as it's deprecated ` +
+              `and not used in this module.`,
+          parsedDocument,
+          severity: Severity.WARNING,
+          sourceRange: hrefRange
+        });
+        // TODO implement fix that removes the import.
+        warnings.push(warning);
+      }
+    }
+  }
+}
+
+/**
+ * Looks for dom-modules that use iron-flex-layout classes (e.g. <div class="layout horizontal">)
+ */
+function modulesUsingFlexLayoutClasses(document: Document) {
+  const modules: dom5.Node[] = [];
+  for (const element of document.getFeatures({ kind: 'polymer-element' })) {
+    const domModule = element.domModule;
+    if (!domModule) {
+      continue;
+    }
+    const template = dom5.query(domModule, p.hasTagName('template'));
+    if (!template) {
+      continue;
+    }
+    if (dom5.query(
+          treeAdapters.default.getTemplateContent(template),
+          flexLayoutClassesSelector)) {
+      modules.push(domModule);
+    }
+  }
+  return modules;
+}
+
+/**
+ * Looks for dom-modules that use iron-flex-layout classes (e.g. <div class="layout horizontal">) without
+ * including the required styles via <style include=""></style>.
+ */
+// function modulesRequiringStyleIncludes(document: Document) {
+//   const modules: dom5.Node[] = [];
+//   for (const element of document.getFeatures({ kind: 'polymer-element' })) {
+//     const domModule = element.domModule;
+//     if (!domModule) {
+//       continue;
+//     }
+//     const template = dom5.query(domModule, p.hasTagName('template'));
+//     if (!template) {
+//       continue;
+//     }
+//     const templateContent = treeAdapters.default.getTemplateContent(template);
+//     const styleNode = dom5.query(templateContent, p.hasTagName('style'));
+//     const styleInclude = styleNode ? dom5.getAttribute(styleNode, 'include') || '' : '';
+//     const styleModulesToInclude = [];
+//     for (const module in validModules) {
+//       if (styleInclude.indexOf(module) === -1 &&
+//         dom5.query(templateContent, validModules[module])) {
+//         styleModulesToInclude.push(module);
+//       }
+//     }
+//     if (styleModulesToInclude.length) {
+//       modules.push(domModule);
+//     }
+//   }
+//   return modules;
+// }
+
+
+// TODO(valdrin) move this in commons or something.
+/* ---- START copy-pasted from content-to-slot-usages. --- */
+function elementSelectorToPredicate(simpleSelector: string): dom5.Predicate {
+  const parsed = cssWhat(simpleSelector);
+  // The output of cssWhat is two levels of arrays. The outer level are any
+  // selectors joined with a comma, so it matches if any of the inner selectors
+  // match. The inner array are simple selectors like `.foo` and `#bar` which
+  // must all match.
+  return dom5.predicates.OR(...parsed.map((simpleSelectors) => {
+    return dom5.predicates.AND(
+        ...simpleSelectors.map(simpleSelectorToPredicate));
+  }));
+}
+
+function simpleSelectorToPredicate(selector: cssWhat.Simple) {
+  switch (selector.type) {
+    case 'adjacent':
+    case 'child':
+    case 'descendant':
+    case 'parent':
+    case 'sibling':
+    case 'pseudo':
+      throw new Error(`Unsupported CSS operator: ${selector.type}`);
+    case 'attribute':
+      return attributeSelectorToPredicate(selector);
+    case 'tag':
+      return dom5.predicates.hasTagName(selector.name);
+    case 'universal':
+      return () => true;
+  }
+  const never: never = selector;
+  throw new Error(`Unexpected node type from css parser: ${never}`);
+}
+
+function attributeSelectorToPredicate(selector: cssWhat.Attribute):
+    dom5.Predicate {
+  switch (selector.action) {
+    case 'exists':
+      return dom5.predicates.hasAttr(selector.name);
+    case 'equals':
+      return dom5.predicates.hasAttrValue(selector.name, selector.value);
+    case 'start':
+      return (el) => {
+        const attrValue = dom5.getAttribute(el, selector.name);
+        return attrValue != null && attrValue.startsWith(selector.value);
+      };
+    case 'end':
+      return (el) => {
+        const attrValue = dom5.getAttribute(el, selector.name);
+        return attrValue != null && attrValue.endsWith(selector.value);
+      };
+    case 'element':
+      return dom5.predicates.hasSpaceSeparatedAttrValue(
+          selector.name, selector.value);
+    case 'any':
+      return (el) => {
+        const attrValue = dom5.getAttribute(el, selector.name);
+        return attrValue != null && attrValue.includes(selector.value);
+      };
+  }
+  const never: never = selector.action;
+  throw new Error(
+      `Unexpected type of attribute matcher from CSS parser ${never}`);
+}
+/* ---- END copy-paste from content-to-slot-usages. --- */
+
+registry.register(new IronFlexLayoutClasses());

--- a/src/polymer/iron-flex-layout-classes.ts
+++ b/src/polymer/iron-flex-layout-classes.ts
@@ -52,14 +52,16 @@ const styleModules = [
   },
   {
     name: 'iron-flex-factors',
+    // Purposefully skip `.flex` as it's already defined in the iron-flex module.
     selector: elementSelectorToPredicate(
         '.flex-1, .flex-2, .flex-3, .flex-4, .flex-5, .flex-6, .flex-7, ' +
         '.flex-8, .flex-9, .flex-10, .flex-11, .flex-12')
   },
   {
     name: 'iron-positioning',
+    // Purposefully skip `[hidden]` as it's too generic as selector.
     selector: elementSelectorToPredicate(
-        '.block, [hidden], .invisible, .relative, .fit, body.fullbleed, ' +
+        '.block, .invisible, .relative, .fit, body.fullbleed, ' +
         '.scroll, .fixed-bottom, .fixed-left, .fixed-top, .fixed-right')
   }
 ];

--- a/src/polymer/iron-flex-layout-classes.ts
+++ b/src/polymer/iron-flex-layout-classes.ts
@@ -138,7 +138,7 @@ ${indent}<style include="${missingModules}"></style>`,
     if (!body || !body.__location) {
       return warnings;
     }
-    const missingModules = getMissingStyleModules(body);
+    const missingModules = getMissingStyleModules(parsedDocument.ast);
     if (!missingModules) {
       return warnings;
     }

--- a/src/polymer/iron-flex-layout-classes.ts
+++ b/src/polymer/iron-flex-layout-classes.ts
@@ -69,6 +69,7 @@ class IronFlexLayoutClasses extends HtmlRule {
         continue;
       }
       // Does it use any of the iron-flex-layout classes?
+      // TODO(valdrin) group by style modules used instead of adding them all.
       const templateContent = treeAdapters.default.getTemplateContent(template);
       if (!dom5.query(templateContent, ironFlexLayoutClasses)) {
         continue;

--- a/src/polymer/iron-flex-layout-classes.ts
+++ b/src/polymer/iron-flex-layout-classes.ts
@@ -89,7 +89,18 @@ class IronFlexLayoutClasses extends HtmlRule {
       parsedDocument: ParsedHtmlDocument, document: Document,
       warnings: FixableWarning[]) {
     // Search in the dom-modules.
-    for (const domModule of document.getFeatures({kind: 'dom-module'})) {
+    for (const domModule of document.getFeatures({ kind: 'dom-module' })) {
+      const misplacedStyle = dom5.query(domModule.astNode, p.hasTagName('style'))
+      if (misplacedStyle) {
+        warnings.push(new FixableWarning({
+          code: 'iron-flex-layout-classes',
+          message: `Style outside template. Run \`move-style-into-template\` rule.`,
+          parsedDocument,
+          severity: Severity.ERROR,
+          sourceRange: parsedDocument.sourceRangeForStartTag(misplacedStyle)!
+        }));
+        continue;
+      }
       const template = dom5.query(domModule.astNode, p.hasTagName('template'));
       if (!template) {
         continue;

--- a/src/polymer/iron-flex-layout-classes.ts
+++ b/src/polymer/iron-flex-layout-classes.ts
@@ -67,6 +67,11 @@ const styleModules = [
   }
 ];
 
+declare interface StyleModule {
+  module: string;
+  node: dom5.Node;
+}
+
 const styleModulesRegex = /iron-(flex|positioning)/;
 
 const isStyleInclude = p.AND(p.hasTagName('style'), p.hasAttr('include'));
@@ -159,8 +164,7 @@ ${indent}</custom-style>`,
   }
 }
 
-function getMissingStyleModules(rootNode: dom5.Node):
-    {module: string, node: dom5.Node}[] {
+function getMissingStyleModules(rootNode: dom5.Node): StyleModule[] {
   let includes = '';
   const modules = {};
   dom5.nodeWalkAll(rootNode, (node: dom5.Node) => {
@@ -187,8 +191,7 @@ function getMissingStyleModules(rootNode: dom5.Node):
 }
 
 function createWarning(
-    parsedDocument: ParsedHtmlDocument,
-    missingModules: {module: string, node: dom5.Node}[]) {
+    parsedDocument: ParsedHtmlDocument, missingModules: StyleModule[]) {
   const multi = missingModules.length > 1;
   const node = missingModules[0].node;
   const modules = missingModules.map((m) => m.module).join(' ');

--- a/src/polymer/iron-flex-layout-classes.ts
+++ b/src/polymer/iron-flex-layout-classes.ts
@@ -79,7 +79,31 @@ const isStyleInclude = p.AND(p.hasTagName('style'), p.hasAttr('include'));
 class IronFlexLayoutClasses extends HtmlRule {
   code = 'iron-flex-layout-classes';
   description = stripIndent(`
-    Warns when iron-flex-layout classes are used without including the style modules.
+      Warns when iron-flex-layout classes are used without including the style modules.
+
+      This:
+
+          <link rel="import" href="../iron-flex-layout/iron-flex-layout-classes.html">
+          <dom-module>
+            <template>
+              <style>
+                :host { diplay: block; }
+              </style>
+              <div class="layout vertical">hello</div>
+            </template>
+          <dom-module>
+
+      Should instead be written as:
+
+          <link rel="import" href="../iron-flex-layout/iron-flex-layout-classes.html">
+          <dom-module>
+            <template>
+              <style include="iron-flex">
+                :host { diplay: block; }
+              </style>
+              <div class="layout vertical">hello</div>
+            </template>
+          <dom-module>
   `).trim();
 
   async checkDocument(parsedDocument: ParsedHtmlDocument, document: Document) {

--- a/src/polymer/iron-flex-layout-classes.ts
+++ b/src/polymer/iron-flex-layout-classes.ts
@@ -125,18 +125,17 @@ ${indent}<style include="${missingModules}"></style>`,
       }
       warnings.push(warning);
     }
-    // Search in the main document.
-    if (!parsedDocument.ast)
-      return;
     const body = dom5.query(parsedDocument.ast, p.hasTagName('body'));
     // Handle files like `<dom-module></dom-module> <body><p>hello</p></body>`
     // where a "fake" body node would be created by dom-module. Skip these
     // cases, dear user please write proper HTML ¯\_(ツ)_/¯
-    if (!body || !body.__location)
+    if (!body || !body.__location) {
       return;
+    }
     const missingModules = getMissingStyleModules(body);
-    if (!missingModules)
+    if (!missingModules) {
       return;
+    }
     // TODO(valdrin): update the warning location to be at the spot where
     // the class is used.
     const warning = createWarning(parsedDocument, body, missingModules);

--- a/src/polymer/iron-flex-layout-classes.ts
+++ b/src/polymer/iron-flex-layout-classes.ts
@@ -84,12 +84,8 @@ class IronFlexLayoutClasses extends HtmlRule {
       parsedDocument: ParsedHtmlDocument, document: Document,
       warnings: FixableWarning[]) {
     // Search in the dom-modules.
-    for (const element of document.getFeatures({kind: 'polymer-element'})) {
-      const domModule = element.domModule;
-      if (!domModule) {
-        continue;
-      }
-      const template = dom5.query(domModule, p.hasTagName('template'));
+    for (const domModule of document.getFeatures({kind: 'dom-module'})) {
+      const template = dom5.query(domModule.astNode, p.hasTagName('template'));
       if (!template) {
         continue;
       }
@@ -100,7 +96,8 @@ class IronFlexLayoutClasses extends HtmlRule {
       }
       // TODO(valdrin): update the warning location to be at the spot where
       // the class is used.
-      const warning = createWarning(parsedDocument, domModule, missingModules);
+      const warning =
+          createWarning(parsedDocument, domModule.astNode, missingModules);
       const styleNode = dom5.query(templateContent, p.hasTagName('style'));
       if (!styleNode) {
         const indent = getIndentationInside(templateContent);

--- a/src/polymer/iron-flex-layout-classes.ts
+++ b/src/polymer/iron-flex-layout-classes.ts
@@ -129,6 +129,8 @@ class IronFlexLayoutClasses extends HtmlRule {
       if (!missingModules) {
         continue;
       }
+      // Add fix on last warning, we'll add all the missing modules in the same
+      // style node.
       const warning = warnings[warnings.length - 1];
       const styleNode = getStyleNodeToEdit(templateContent);
       if (!styleNode) {
@@ -159,6 +161,8 @@ ${indent}<style include="${missingModules}"></style>`)];
     if (!missingModules) {
       return warnings;
     }
+    // Add fix on last warning, we'll add all the missing modules in the same
+    // style node.
     const warning = warnings[warnings.length - 1];
     const indent = getIndentationInside(body);
     warning.fix = [prependContent(parsedDocument, body, `

--- a/src/polymer/iron-flex-layout-classes.ts
+++ b/src/polymer/iron-flex-layout-classes.ts
@@ -98,6 +98,8 @@ class IronFlexLayoutClasses extends HtmlRule {
       if (!missingModules) {
         continue;
       }
+      // TODO(valdrin): update the warning location to be at the spot where
+      // the class is used.
       const warning = createWarning(parsedDocument, domModule, missingModules);
       const styleNode = dom5.query(templateContent, p.hasTagName('style'));
       if (!styleNode) {
@@ -125,11 +127,16 @@ ${indent}<style include="${missingModules}"></style>`,
     if (!parsedDocument.ast)
       return;
     const body = dom5.query(parsedDocument.ast, p.hasTagName('body'));
-    if (!body)
+    // Handle files like `<dom-module></dom-module> <body><p>hello</p></body>`
+    // where a "fake" body node would be created by dom-module. Skip these
+    // cases, dear user please write proper HTML ¯\_(ツ)_/¯
+    if (!body || !body.__location)
       return;
     const missingModules = getMissingStyleModules(body);
     if (!missingModules)
       return;
+    // TODO(valdrin): update the warning location to be at the spot where
+    // the class is used.
     const warning = createWarning(parsedDocument, body, missingModules);
     const indent = getIndentationInside(body);
     warning.fix = [{

--- a/src/polymer/iron-flex-layout-classes.ts
+++ b/src/polymer/iron-flex-layout-classes.ts
@@ -42,24 +42,25 @@ const styleModules = [
   },
   {
     name: 'iron-flex-alignment',
+    // Skip `.layout.center, .layout.center-center, .layout.center-justified`
+    // as they're already defined in the `iron-flex` module.
     selector: elementSelectorToPredicate(
-        '.layout.start, .layout.center, .layout.center-center, .layout.end, ' +
-        '.layout.baseline, .layout.start-justified, .layout.center-justified, ' +
-        '.layout.center-center, .layout.end-justified, .layout.around-justified, ' +
-        '.layout.justified, .self-start, .self-center, .self-end, .self-stretch, ' +
-        '.self-baseline, .layout.start-aligned, .layout.end-aligned, ' +
-        '.layout.center-aligned, .layout.between-aligned, .layout.around-aligned')
+        '.layout.start, .layout.end, .layout.baseline, .layout.start-justified, ' +
+        '.layout.end-justified, .layout.around-justified, .layout.justified, ' +
+        '.self-start, .self-center, .self-end, .self-stretch, .self-baseline, ' +
+        '.layout.start-aligned, .layout.end-aligned, .layout.center-aligned, ' +
+        '.layout.between-aligned, .layout.around-aligned')
   },
   {
     name: 'iron-flex-factors',
-    // Purposefully skip `.flex` as it's already defined in the iron-flex module.
+    // Skip `.flex` as it's already defined in the `iron-flex` module.
     selector: elementSelectorToPredicate(
         '.flex-1, .flex-2, .flex-3, .flex-4, .flex-5, .flex-6, .flex-7, ' +
         '.flex-8, .flex-9, .flex-10, .flex-11, .flex-12')
   },
   {
     name: 'iron-positioning',
-    // Purposefully skip `[hidden]` as it's too generic as selector.
+    // Skip `[hidden]` as it's a too generic selector.
     selector: elementSelectorToPredicate(
         '.block, .invisible, .relative, .fit, body.fullbleed, ' +
         '.scroll, .fixed-bottom, .fixed-left, .fixed-top, .fixed-right')

--- a/src/polymer/iron-flex-layout-classes.ts
+++ b/src/polymer/iron-flex-layout-classes.ts
@@ -18,11 +18,11 @@ import {Document, ParsedHtmlDocument, Severity} from 'polymer-analyzer';
 
 import {HtmlRule} from '../html/rule';
 import {registry} from '../registry';
-import {FixableWarning, Replacement} from '../warning';
+import {FixableWarning} from '../warning';
 
 import stripIndent = require('strip-indent');
 
-import {elementSelectorToPredicate, getIndentationInside} from '../html/util';
+import {elementSelectorToPredicate, getIndentationInside, addAttribute, prependContentInto} from '../html/util';
 
 const p = dom5.predicates;
 
@@ -137,7 +137,7 @@ class IronFlexLayoutClasses extends HtmlRule {
           dom5.query(templateContent, p.hasTagName('style'));
       if (!styleNode) {
         const indent = getIndentationInside(templateContent);
-        warning.fix = [prependContent(parsedDocument, template, `
+        warning.fix = [prependContentInto(parsedDocument, template, `
 ${indent}<style include="${missingModules}"></style>`)];
       } else if (dom5.hasAttribute(styleNode, 'include')) {
         const include = dom5.getAttribute(styleNode, 'include')!;
@@ -176,7 +176,7 @@ ${indent}<style include="${missingModules}"></style>`)];
       }];
     } else {
       const indent = getIndentationInside(body);
-      warning.fix = [prependContent(parsedDocument, body, `
+      warning.fix = [prependContentInto(parsedDocument, body, `
 ${indent}<custom-style>
 ${indent}  <style is="custom-style" include="${missingModules}"></style>
 ${indent}</custom-style>`)];
@@ -253,34 +253,6 @@ function getStyleNodeWithInclude(node: dom5.Node) {
     }
   }
   return styleToEdit;
-}
-
-function addAttribute(
-    parsedDocument: ParsedHtmlDocument,
-    node: dom5.Node,
-    attribute: string,
-    attributeValue: string): Replacement {
-  const tagRange = parsedDocument.sourceRangeForStartTag(node)!;
-  const range = {
-    file: tagRange.file,
-    start: {line: tagRange.end.line, column: tagRange.end.column - 1},
-    end: {line: tagRange.end.line, column: tagRange.end.column - 1}
-  };
-  const replacementText = ` ${attribute}="${attributeValue}"`;
-  return {replacementText, range};
-}
-
-function prependContent(
-    parsedDocument: ParsedHtmlDocument,
-    node: dom5.Node,
-    replacementText: string): Replacement {
-  const tagRange = parsedDocument.sourceRangeForStartTag(node)!;
-  const range = {
-    file: tagRange.file,
-    start: {line: tagRange.end.line, column: tagRange.end.column},
-    end: {line: tagRange.end.line, column: tagRange.end.column}
-  };
-  return {replacementText, range};
 }
 
 registry.register(new IronFlexLayoutClasses());

--- a/src/polymer/iron-flex-layout-import.ts
+++ b/src/polymer/iron-flex-layout-import.ts
@@ -59,8 +59,9 @@ class IronFlexLayoutImport extends HtmlRule {
           parsedDocument.sourceRangeForAttributeValue(imp, 'href')!;
       const warning = new FixableWarning({
         code: 'iron-flex-layout-import',
-        message: `${href} import is deprecated. ` +
-            `Replace with ${correctImport} import.`,
+        message: `${href} import is deprecated in iron-flex-layout v1, and not shipped in iron-flex-layout v2.x.
+Replace it with ${correctImport} import.
+Run \`iron-flex-layout-classes\` to include the required style modules.`,
         parsedDocument,
         severity: Severity.WARNING,
         sourceRange: hrefRange

--- a/src/polymer/iron-flex-layout-import.ts
+++ b/src/polymer/iron-flex-layout-import.ts
@@ -1,0 +1,72 @@
+/**
+ * @license
+ * Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at
+ * http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at
+ * http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+import * as dom5 from 'dom5';
+import {Document, ParsedHtmlDocument, Severity} from 'polymer-analyzer';
+
+import {HtmlRule} from '../html/rule';
+import {registry} from '../registry';
+import {FixableWarning} from '../warning';
+
+import stripIndent = require('strip-indent');
+
+const deprecatedBase = 'iron-flex-layout/classes';
+const replacementImport = 'iron-flex-layout/iron-flex-layout-classes.html';
+
+class IronFlexLayoutImport extends HtmlRule {
+  code = 'iron-flex-layout-import';
+  description = stripIndent(`
+      Warns when the deprecated iron-flex-layout/classes/*.html files are imported.
+  `).trim();
+
+  async checkDocument(parsedDocument: ParsedHtmlDocument, document: Document) {
+    const warnings: FixableWarning[] = [];
+
+    this.convertDeclarations(parsedDocument, document, warnings);
+
+    return warnings;
+  }
+
+  convertDeclarations(
+      parsedDocument: ParsedHtmlDocument, document: Document,
+      warnings: FixableWarning[]) {
+    const imports = document.getFeatures({ kind: 'import' });
+    for (const imp of imports) {
+      const href = dom5.getAttribute(imp.astNode, 'href') || '';
+      const i = href.indexOf(deprecatedBase);
+      if (i === -1) {
+        continue;
+      }
+      const correctImport = href.replace(href.substr(i), replacementImport);
+      // Use excludeQuotes = true when Polymer/polymer-analyzer#737 is fixed
+      const hrefRange = parsedDocument.sourceRangeForAttributeValue(imp.astNode, 'href')!;
+      const warning = new FixableWarning({
+        code: 'iron-flex-layout-import',
+        message:
+            `${href} import is deprecated. ` +
+            `Replace with ${correctImport} import.`,
+        parsedDocument,
+        severity: Severity.WARNING,
+        sourceRange: hrefRange
+      });
+      warning.fix = [{
+        replacementText: `"${correctImport}"`,
+        range: hrefRange
+      }];
+      warnings.push(warning);
+    }
+  }
+}
+
+registry.register(new IronFlexLayoutImport());

--- a/src/polymer/iron-flex-layout-import.ts
+++ b/src/polymer/iron-flex-layout-import.ts
@@ -76,7 +76,7 @@ class IronFlexLayoutImport extends HtmlRule {
         message: `${href} import is deprecated in iron-flex-layout v1, ` +
             `and not shipped in iron-flex-layout v2.
 Replace it with ${correctImport} import.
-Run \`iron-flex-layout-classes\` to include the required style modules.`,
+Run the lint rule \`iron-flex-layout-classes\` with \`--fix\` to include the required style modules.`,
         parsedDocument,
         severity: Severity.WARNING,
         sourceRange: parsedDocument.sourceRangeForAttributeValue(imp, 'href')!

--- a/src/polymer/iron-flex-layout-import.ts
+++ b/src/polymer/iron-flex-layout-import.ts
@@ -41,7 +41,7 @@ class IronFlexLayoutImport extends HtmlRule {
   convertDeclarations(
       parsedDocument: ParsedHtmlDocument, document: Document,
       warnings: FixableWarning[]) {
-    const imports = document.getFeatures({ kind: 'import' });
+    const imports = document.getFeatures({kind: 'import'});
     for (const imp of imports) {
       const href = dom5.getAttribute(imp.astNode, 'href') || '';
       const i = href.indexOf(deprecatedBase);
@@ -50,20 +50,17 @@ class IronFlexLayoutImport extends HtmlRule {
       }
       const correctImport = href.replace(href.substr(i), replacementImport);
       // Use excludeQuotes = true when Polymer/polymer-analyzer#737 is fixed
-      const hrefRange = parsedDocument.sourceRangeForAttributeValue(imp.astNode, 'href')!;
+      const hrefRange =
+          parsedDocument.sourceRangeForAttributeValue(imp.astNode, 'href')!;
       const warning = new FixableWarning({
         code: 'iron-flex-layout-import',
-        message:
-            `${href} import is deprecated. ` +
+        message: `${href} import is deprecated. ` +
             `Replace with ${correctImport} import.`,
         parsedDocument,
         severity: Severity.WARNING,
         sourceRange: hrefRange
       });
-      warning.fix = [{
-        replacementText: `"${correctImport}"`,
-        range: hrefRange
-      }];
+      warning.fix = [{replacementText: `"${correctImport}"`, range: hrefRange}];
       warnings.push(warning);
     }
   }

--- a/src/polymer/iron-flex-layout-import.ts
+++ b/src/polymer/iron-flex-layout-import.ts
@@ -21,7 +21,8 @@ import {FixableWarning} from '../warning';
 
 import stripIndent = require('strip-indent');
 
-const deprecatedImports = /iron-flex-layout\/classes\/iron-(shadow-)?flex-layout.html/;
+const deprecatedImports =
+    /iron-flex-layout\/classes\/iron-(shadow-)?flex-layout.html/;
 const replacementImport = 'iron-flex-layout/iron-flex-layout-classes.html';
 
 const p = dom5.predicates;

--- a/src/rules.ts
+++ b/src/rules.ts
@@ -27,5 +27,5 @@ import './polymer/databind-with-unknown-property';
 import './polymer/element-before-dom-module';
 import './polymer/set-unknown-attribute';
 import './polymer/unbalanced-delimiters';
-import './polymer/iron-flex-layout-import';
-import './polymer/iron-flex-layout-classes';
+
+import './polymer/elements/rules';

--- a/src/rules.ts
+++ b/src/rules.ts
@@ -27,3 +27,4 @@ import './polymer/databind-with-unknown-property';
 import './polymer/element-before-dom-module';
 import './polymer/set-unknown-attribute';
 import './polymer/unbalanced-delimiters';
+import './polymer/iron-flex-layout-classes';

--- a/src/rules.ts
+++ b/src/rules.ts
@@ -27,4 +27,5 @@ import './polymer/databind-with-unknown-property';
 import './polymer/element-before-dom-module';
 import './polymer/set-unknown-attribute';
 import './polymer/unbalanced-delimiters';
+import './polymer/iron-flex-layout-import';
 import './polymer/iron-flex-layout-classes';

--- a/src/test/polymer/iron-flex-layout-classes_test.ts
+++ b/src/test/polymer/iron-flex-layout-classes_test.ts
@@ -45,17 +45,20 @@ suite(ruleId, () => {
     const warnings = await linter.lint([`${ruleId}/before-fixes.html`]);
     assert.deepEqual(warningPrinter.prettyPrint(warnings), [
       `
-<dom-module id="no-style">
-~~~~~~~~~~~~~~~~~~~~~~~~~~`,
+  <dom-module id="no-style">
+  ~~~~~~~~~~~~~~~~~~~~~~~~~~`,
       `
-<dom-module id="with-style">
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~`,
+  <dom-module id="with-style">
+  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~`,
       `
-<dom-module id="with-include">
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~`,
+  <dom-module id="with-include">
+  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~`,
       `
-<dom-module id="with-partial-include">
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~`,
+  <dom-module id="with-partial-include">
+  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~`,
+      `
+<body class="fullbleed">
+~~~~~~~~~~~~~~~~~~~~~~~~`,
     ]);
 
     assert.deepEqual(warnings.map((w) => w.message), [
@@ -79,6 +82,11 @@ Import it in the template style include.`,
   iron-flex-reverse iron-flex-factors
 
 Import them in the template style include.`,
+      `Style module is used but not imported:
+
+  iron-positioning
+
+Import it in the template style include.`,
     ]);
   });
 

--- a/src/test/polymer/iron-flex-layout-classes_test.ts
+++ b/src/test/polymer/iron-flex-layout-classes_test.ts
@@ -69,6 +69,9 @@ suite(ruleId, () => {
     <style>
     ~~~~~~~`,
       `
+          <div class="layout horizontal">
+                     ~~~~~~~~~~~~~~~~~~~`,
+      `
 <body class="fullbleed">
             ~~~~~~~~~~~`,
     ]);
@@ -89,6 +92,8 @@ Import it in the template style include.`,
       `"iron-flex-factors" style module is used but not imported.
 Import it in the template style include.`,
       'Style outside template. Run `move-style-into-template` rule.',
+      `"iron-flex" style module is used but not imported.
+Import it in the template style include.`,
       `"iron-positioning" style module is used but not imported.
 Import it in the template style include.`,
     ]);

--- a/src/test/polymer/iron-flex-layout-classes_test.ts
+++ b/src/test/polymer/iron-flex-layout-classes_test.ts
@@ -59,22 +59,22 @@ suite(ruleId, () => {
     ]);
 
     assert.deepEqual(warnings.map((w) => w.message), [
-      `This style module is used but not imported:
+      `Style module is used but not imported:
 
   iron-flex
 
 Import it in the template style include.`,
-      `This style module is used but not imported:
+      `Style module is used but not imported:
 
   iron-flex
 
 Import it in the template style include.`,
-      `This style module is used but not imported:
+      `Style module is used but not imported:
 
   iron-flex
 
 Import it in the template style include.`,
-      `These style modules are used but not imported:
+      `Style modules are used but not imported:
 
   iron-flex-reverse iron-flex-factors
 

--- a/src/test/polymer/iron-flex-layout-classes_test.ts
+++ b/src/test/polymer/iron-flex-layout-classes_test.ts
@@ -57,6 +57,9 @@ suite(ruleId, () => {
   <dom-module id="with-partial-include">
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~`,
       `
+    <style>
+    ~~~~~~~`,
+      `
 <body class="fullbleed">
 ~~~~~~~~~~~~~~~~~~~~~~~~`,
     ]);
@@ -82,6 +85,7 @@ Import them in the template style include.`,
   iron-flex-reverse iron-flex-factors
 
 Import them in the template style include.`,
+  'Style outside template. Run `move-style-into-template` rule.',
       `Style module is used but not imported:
 
   iron-positioning

--- a/src/test/polymer/iron-flex-layout-classes_test.ts
+++ b/src/test/polymer/iron-flex-layout-classes_test.ts
@@ -25,16 +25,6 @@ const fixtures_dir = path.join(__dirname, '..', '..', '..', 'test');
 
 const ruleId = 'iron-flex-layout-classes';
 
-const warningMsg = `Missing style includes for iron-flex-layout classes. Include these style modules:
-
-            <dom-module id="my-element">
-              <template>
-                <style include="iron-flex iron-flex-reverse iron-flex-alignment iron-flex-factors iron-positioning">
-                  ...
-                </style>
-                ...
-              </template>`;
-
 suite(ruleId, () => {
   let analyzer: Analyzer;
   let warningPrinter: WarningPrettyPrinter;
@@ -61,15 +51,34 @@ suite(ruleId, () => {
 <dom-module id="with-style">
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~`,
       `
-<dom-module id="with-style-include">
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~`,
+<dom-module id="with-include">
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~`,
       `
-<dom-module id="with-partial-iron-flex-include">
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~`,
+<dom-module id="with-partial-include">
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~`,
     ]);
 
     assert.deepEqual(warnings.map((w) => w.message), [
-      warningMsg, warningMsg, warningMsg, warningMsg
+      `This style module is used but not imported:
+
+  iron-flex
+
+Import it in the template style include.`,
+      `This style module is used but not imported:
+
+  iron-flex
+
+Import it in the template style include.`,
+      `This style module is used but not imported:
+
+  iron-flex
+
+Import it in the template style include.`,
+      `These style modules are used but not imported:
+
+  iron-flex-reverse iron-flex-factors
+
+Import them in the template style include.`,
     ]);
   });
 

--- a/src/test/polymer/iron-flex-layout-classes_test.ts
+++ b/src/test/polymer/iron-flex-layout-classes_test.ts
@@ -85,7 +85,7 @@ Import them in the template style include.`,
   iron-flex-reverse iron-flex-factors
 
 Import them in the template style include.`,
-  'Style outside template. Run `move-style-into-template` rule.',
+      'Style outside template. Run `move-style-into-template` rule.',
       `Style module is used but not imported:
 
   iron-positioning

--- a/src/test/polymer/iron-flex-layout-classes_test.ts
+++ b/src/test/polymer/iron-flex-layout-classes_test.ts
@@ -1,0 +1,66 @@
+/**
+ * @license
+ * Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at
+ * http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at
+ * http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+import {assert} from 'chai';
+import * as path from 'path';
+import {Analyzer, FSUrlLoader} from 'polymer-analyzer';
+
+import {Linter} from '../../linter';
+import {registry} from '../../registry';
+// import {applyEdits, makeParseLoader} from '../../warning';
+import {WarningPrettyPrinter} from '../util';
+
+const fixtures_dir = path.join(__dirname, '..', '..', '..', 'test');
+
+const ruleId = 'iron-flex-layout-classes';
+
+suite(ruleId, () => {
+  let analyzer: Analyzer;
+  let warningPrinter: WarningPrettyPrinter;
+  let linter: Linter;
+
+  setup(() => {
+    analyzer = new Analyzer({urlLoader: new FSUrlLoader(fixtures_dir)});
+    warningPrinter = new WarningPrettyPrinter();
+    linter = new Linter(registry.getRules([ruleId]), analyzer);
+  });
+
+  test('works in the trivial case', async() => {
+    const warnings = await linter.lint([]);
+    assert.deepEqual(warnings, []);
+  });
+
+  test('warns for the proper cases and with the right messages', async() => {
+    const warnings = await linter.lint([`${ruleId}/before-fixes.html`]);
+    assert.deepEqual(warningPrinter.prettyPrint(warnings), [
+      `
+<link rel="import" href="./iron-flex-layout/classes/iron-flex-layout.html">
+                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~`,
+    ]);
+
+    assert.deepEqual(warnings.map((w) => w.message), [
+      'iron-flex-layout/classes/iron-flex-layout.html import is deprecated. Replace with iron-flex-layout/iron-flex-layout-classes.html import.'
+    ]);
+  });
+
+  // test('applies automatic-safe fixes', async() => {
+  //   const warnings = await linter.lint([`${ruleId}/before-fixes.html`]);
+  //   const edits = warnings.filter((w) => w.fix).map((w) => w.fix!);
+  //   const loader = makeParseLoader(analyzer);
+  //   const result = await applyEdits(edits, loader);
+  //   assert.deepEqual(
+  //       result.editedFiles.get(`${ruleId}/before-fixes.html`),
+  //       (await loader(`${ruleId}/after-fixes.html`)).contents);
+  // });
+});

--- a/src/test/polymer/iron-flex-layout-classes_test.ts
+++ b/src/test/polymer/iron-flex-layout-classes_test.ts
@@ -46,50 +46,50 @@ suite(ruleId, () => {
     assert.deepEqual(warningPrinter.prettyPrint(warnings), [
       `
       <div class="layout horizontal">
-      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~`,
+                 ~~~~~~~~~~~~~~~~~~~`,
       `
       <div class="layout horizontal">
-      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~`,
+                 ~~~~~~~~~~~~~~~~~~~`,
+      `
+        <p class="flex">lorem</p>
+                 ~~~~~~`,
       `
       <div class="flex">
-      ~~~~~~~~~~~~~~~~~~`,
+                 ~~~~~~`,
+      `
+        <p class="flex-1">lorem</p>
+                 ~~~~~~~~`,
       `
       <div class="layout horizontal-reverse">
-      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~`,
+                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~`,
+      `
+        <p class="flex-1">ipsum</p>
+                 ~~~~~~~~`,
       `
     <style>
     ~~~~~~~`,
       `
 <body class="fullbleed">
-~~~~~~~~~~~~~~~~~~~~~~~~`,
+            ~~~~~~~~~~~`,
     ]);
 
     assert.deepEqual(warnings.map((w) => w.message), [
-      `Style module is used but not imported:
-
-  iron-flex
-
+      `"iron-flex" style module is used but not imported.
 Import it in the template style include.`,
-      `Style module is used but not imported:
-
-  iron-flex
-
+      `"iron-flex" style module is used but not imported.
 Import it in the template style include.`,
-      `Style modules are used but not imported:
-
-  iron-flex iron-flex-factors
-
-Import them in the template style include.`,
-      `Style modules are used but not imported:
-
-  iron-flex-reverse iron-flex-factors
-
-Import them in the template style include.`,
+      `"iron-flex" style module is used but not imported.
+Import it in the template style include.`,
+      `"iron-flex" style module is used but not imported.
+Import it in the template style include.`,
+      `"iron-flex-factors" style module is used but not imported.
+Import it in the template style include.`,
+      `"iron-flex-reverse" style module is used but not imported.
+Import it in the template style include.`,
+      `"iron-flex-factors" style module is used but not imported.
+Import it in the template style include.`,
       'Style outside template. Run `move-style-into-template` rule.',
-      `Style module is used but not imported:
-
-  iron-positioning
-
+      `"iron-positioning" style module is used but not imported.
 Import it in the template style include.`,
     ]);
   });

--- a/src/test/polymer/iron-flex-layout-classes_test.ts
+++ b/src/test/polymer/iron-flex-layout-classes_test.ts
@@ -45,17 +45,17 @@ suite(ruleId, () => {
     const warnings = await linter.lint([`${ruleId}/before-fixes.html`]);
     assert.deepEqual(warningPrinter.prettyPrint(warnings), [
       `
-  <dom-module id="no-style">
-  ~~~~~~~~~~~~~~~~~~~~~~~~~~`,
+      <div class="layout horizontal">
+      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~`,
       `
-  <dom-module id="with-style">
-  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~`,
+      <div class="layout horizontal">
+      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~`,
       `
-  <dom-module id="with-include">
-  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~`,
+      <div class="flex">
+      ~~~~~~~~~~~~~~~~~~`,
       `
-  <dom-module id="with-partial-include">
-  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~`,
+      <div class="layout horizontal-reverse">
+      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~`,
       `
     <style>
     ~~~~~~~`,

--- a/src/test/polymer/iron-flex-layout-classes_test.ts
+++ b/src/test/polymer/iron-flex-layout-classes_test.ts
@@ -72,11 +72,11 @@ Import it in the template style include.`,
   iron-flex
 
 Import it in the template style include.`,
-      `Style module is used but not imported:
+      `Style modules are used but not imported:
 
-  iron-flex
+  iron-flex iron-flex-factors
 
-Import it in the template style include.`,
+Import them in the template style include.`,
       `Style modules are used but not imported:
 
   iron-flex-reverse iron-flex-factors

--- a/src/test/polymer/iron-flex-layout-import_test.ts
+++ b/src/test/polymer/iron-flex-layout-import_test.ts
@@ -23,17 +23,7 @@ import {WarningPrettyPrinter} from '../util';
 
 const fixtures_dir = path.join(__dirname, '..', '..', '..', 'test');
 
-const ruleId = 'iron-flex-layout-classes';
-
-const warningMsg = `Missing style includes for iron-flex-layout classes. Include these style modules:
-
-            <dom-module id="my-element">
-              <template>
-                <style include="iron-flex iron-flex-reverse iron-flex-alignment iron-flex-factors iron-positioning">
-                  ...
-                </style>
-                ...
-              </template>`;
+const ruleId = 'iron-flex-layout-import';
 
 suite(ruleId, () => {
   let analyzer: Analyzer;
@@ -55,21 +45,12 @@ suite(ruleId, () => {
     const warnings = await linter.lint([`${ruleId}/before-fixes.html`]);
     assert.deepEqual(warningPrinter.prettyPrint(warnings), [
       `
-<dom-module id="no-style">
-~~~~~~~~~~~~~~~~~~~~~~~~~~`,
-      `
-<dom-module id="with-style">
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~`,
-      `
-<dom-module id="with-style-include">
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~`,
-      `
-<dom-module id="with-partial-iron-flex-include">
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~`,
+<link rel="import" href="./iron-flex-layout/classes/iron-flex-layout.html">
+                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~`,
     ]);
 
     assert.deepEqual(warnings.map((w) => w.message), [
-      warningMsg, warningMsg, warningMsg, warningMsg
+      './iron-flex-layout/classes/iron-flex-layout.html import is deprecated. Replace with ./iron-flex-layout/iron-flex-layout-classes.html import.'
     ]);
   });
 

--- a/src/test/polymer/iron-flex-layout-import_test.ts
+++ b/src/test/polymer/iron-flex-layout-import_test.ts
@@ -42,7 +42,8 @@ suite(ruleId, () => {
   });
 
   test('warns when deprecated files are used with the right messages', async() => {
-    const warnings = await linter.lint([`${ruleId}/deprecated-files-before-fixes.html`]);
+    const warnings =
+        await linter.lint([`${ruleId}/deprecated-files-before-fixes.html`]);
     assert.deepEqual(warningPrinter.prettyPrint(warnings), [
       `
 <link rel="import" href="./iron-flex-layout/classes/iron-flex-layout.html">
@@ -62,32 +63,41 @@ Run the lint rule \`iron-flex-layout-classes\` with \`--fix\` to include the req
     ]);
   });
 
-  test('applies automatic-safe fixes when deprecated files are used', async() => {
-    const warnings = await linter.lint([`${ruleId}/deprecated-files-before-fixes.html`]);
-    const edits = warnings.filter((w) => w.fix).map((w) => w.fix!);
-    const loader = makeParseLoader(analyzer);
-    const result = await applyEdits(edits, loader);
-    assert.deepEqual(
-        result.editedFiles.get(`${ruleId}/deprecated-files-before-fixes.html`),
-        (await loader(`${ruleId}/deprecated-files-after-fixes.html`)).contents);
-  });
+  test(
+      'applies automatic-safe fixes when deprecated files are used',
+      async() => {
+        const warnings =
+            await linter.lint([`${ruleId}/deprecated-files-before-fixes.html`]);
+        const edits = warnings.filter((w) => w.fix).map((w) => w.fix!);
+        const loader = makeParseLoader(analyzer);
+        const result = await applyEdits(edits, loader);
+        assert.deepEqual(
+            result.editedFiles.get(
+                `${ruleId}/deprecated-files-before-fixes.html`),
+            (await loader(`${ruleId}/deprecated-files-after-fixes.html`))
+                .contents);
+      });
 
-  test('warns when iron-flex-layout modules are used but not imported', async() => {
-    const warnings = await linter.lint([`${ruleId}/forgot-import-before-fixes.html`]);
-    assert.deepEqual(warningPrinter.prettyPrint(warnings), [
-      `
+  test(
+      'warns when iron-flex-layout modules are used but not imported',
+      async() => {
+        const warnings =
+            await linter.lint([`${ruleId}/forgot-import-before-fixes.html`]);
+        assert.deepEqual(warningPrinter.prettyPrint(warnings), [
+          `
     <style include="iron-flex"></style>
                    ~~~~~~~~~~~`,
-    ]);
+        ]);
 
-    assert.deepEqual(warnings.map((w) => w.message), [
-      `iron-flex-layout style modules are used but not imported.
+        assert.deepEqual(warnings.map((w) => w.message), [
+          `iron-flex-layout style modules are used but not imported.
 Import iron-flex-layout/iron-flex-layout-classes.html`,
-    ]);
-  });
+        ]);
+      });
 
   test('adds missing import by inferring the base path', async() => {
-    const warnings = await linter.lint([`${ruleId}/forgot-import-before-fixes.html`]);
+    const warnings =
+        await linter.lint([`${ruleId}/forgot-import-before-fixes.html`]);
     const edits = warnings.filter((w) => w.fix).map((w) => w.fix!);
     const loader = makeParseLoader(analyzer);
     const result = await applyEdits(edits, loader);
@@ -97,17 +107,21 @@ Import iron-flex-layout/iron-flex-layout-classes.html`,
   });
 
   test('adds missing import by defaulting the base path', async() => {
-    const warnings = await linter.lint([`${ruleId}/forgot-import-no-imports-before-fixes.html`]);
+    const warnings = await linter.lint(
+        [`${ruleId}/forgot-import-no-imports-before-fixes.html`]);
     const edits = warnings.filter((w) => w.fix).map((w) => w.fix!);
     const loader = makeParseLoader(analyzer);
     const result = await applyEdits(edits, loader);
     assert.deepEqual(
-        result.editedFiles.get(`${ruleId}/forgot-import-no-imports-before-fixes.html`),
-        (await loader(`${ruleId}/forgot-import-no-imports-after-fixes.html`)).contents);
+        result.editedFiles.get(
+            `${ruleId}/forgot-import-no-imports-before-fixes.html`),
+        (await loader(`${ruleId}/forgot-import-no-imports-after-fixes.html`))
+            .contents);
   });
 
   test('warns when iron-flex-layout modules are imported but not used', async() => {
-    const warnings = await linter.lint([`${ruleId}/unnecessary-import-before-fixes.html`]);
+    const warnings =
+        await linter.lint([`${ruleId}/unnecessary-import-before-fixes.html`]);
     assert.deepEqual(warningPrinter.prettyPrint(warnings), [
       `
 <link rel="import" href="iron-flex-layout/iron-flex-layout-classes.html">
@@ -115,17 +129,20 @@ Import iron-flex-layout/iron-flex-layout-classes.html`,
     ]);
 
     assert.deepEqual(warnings.map((w) => w.message), [
-      `This import defines style modules that are not being used. Remove it.`,
+      `This import defines style modules that are not being used. It can be removed.`,
     ]);
   });
 
   test('removes unnecessary import', async() => {
-    const warnings = await linter.lint([`${ruleId}/unnecessary-import-before-fixes.html`]);
+    const warnings =
+        await linter.lint([`${ruleId}/unnecessary-import-before-fixes.html`]);
     const edits = warnings.filter((w) => w.fix).map((w) => w.fix!);
     const loader = makeParseLoader(analyzer);
     const result = await applyEdits(edits, loader);
     assert.deepEqual(
-        result.editedFiles.get(`${ruleId}/unnecessary-import-before-fixes.html`),
-        (await loader(`${ruleId}/unnecessary-import-after-fixes.html`)).contents);
+        result.editedFiles.get(
+            `${ruleId}/unnecessary-import-before-fixes.html`),
+        (await loader(`${ruleId}/unnecessary-import-after-fixes.html`))
+            .contents);
   });
 });

--- a/src/test/polymer/iron-flex-layout-import_test.ts
+++ b/src/test/polymer/iron-flex-layout-import_test.ts
@@ -47,10 +47,14 @@ suite(ruleId, () => {
       `
 <link rel="import" href="./iron-flex-layout/classes/iron-flex-layout.html">
                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~`,
+      `
+<link rel="import" href="./iron-flex-layout/classes/iron-shadow-flex-layout.html">
+                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~`,
     ]);
 
     assert.deepEqual(warnings.map((w) => w.message), [
-      './iron-flex-layout/classes/iron-flex-layout.html import is deprecated. Replace with ./iron-flex-layout/iron-flex-layout-classes.html import.'
+      './iron-flex-layout/classes/iron-flex-layout.html import is deprecated. Replace with ./iron-flex-layout/iron-flex-layout-classes.html import.',
+      './iron-flex-layout/classes/iron-shadow-flex-layout.html import is deprecated. Replace with ./iron-flex-layout/iron-flex-layout-classes.html import.',
     ]);
   });
 

--- a/src/test/polymer/iron-flex-layout-import_test.ts
+++ b/src/test/polymer/iron-flex-layout-import_test.ts
@@ -53,8 +53,12 @@ suite(ruleId, () => {
     ]);
 
     assert.deepEqual(warnings.map((w) => w.message), [
-      './iron-flex-layout/classes/iron-flex-layout.html import is deprecated. Replace with ./iron-flex-layout/iron-flex-layout-classes.html import.',
-      './iron-flex-layout/classes/iron-shadow-flex-layout.html import is deprecated. Replace with ./iron-flex-layout/iron-flex-layout-classes.html import.',
+      `./iron-flex-layout/classes/iron-flex-layout.html import is deprecated in iron-flex-layout v1, and not shipped in iron-flex-layout v2.x.
+Replace it with ./iron-flex-layout/iron-flex-layout-classes.html import.
+Run \`iron-flex-layout-classes\` to include the required style modules.`,
+      `./iron-flex-layout/classes/iron-shadow-flex-layout.html import is deprecated in iron-flex-layout v1, and not shipped in iron-flex-layout v2.x.
+Replace it with ./iron-flex-layout/iron-flex-layout-classes.html import.
+Run \`iron-flex-layout-classes\` to include the required style modules.`,
     ]);
   });
 

--- a/src/test/polymer/iron-flex-layout-import_test.ts
+++ b/src/test/polymer/iron-flex-layout-import_test.ts
@@ -41,8 +41,8 @@ suite(ruleId, () => {
     assert.deepEqual(warnings, []);
   });
 
-  test('warns for the proper cases and with the right messages', async() => {
-    const warnings = await linter.lint([`${ruleId}/before-fixes.html`]);
+  test('warns when deprecated files are used with the right messages', async() => {
+    const warnings = await linter.lint([`${ruleId}/deprecated-files-before-fixes.html`]);
     assert.deepEqual(warningPrinter.prettyPrint(warnings), [
       `
 <link rel="import" href="./iron-flex-layout/classes/iron-flex-layout.html">
@@ -62,13 +62,70 @@ Run the lint rule \`iron-flex-layout-classes\` with \`--fix\` to include the req
     ]);
   });
 
-  test('applies automatic-safe fixes', async() => {
-    const warnings = await linter.lint([`${ruleId}/before-fixes.html`]);
+  test('applies automatic-safe fixes when deprecated files are used', async() => {
+    const warnings = await linter.lint([`${ruleId}/deprecated-files-before-fixes.html`]);
     const edits = warnings.filter((w) => w.fix).map((w) => w.fix!);
     const loader = makeParseLoader(analyzer);
     const result = await applyEdits(edits, loader);
     assert.deepEqual(
-        result.editedFiles.get(`${ruleId}/before-fixes.html`),
-        (await loader(`${ruleId}/after-fixes.html`)).contents);
+        result.editedFiles.get(`${ruleId}/deprecated-files-before-fixes.html`),
+        (await loader(`${ruleId}/deprecated-files-after-fixes.html`)).contents);
+  });
+
+  test('warns when iron-flex-layout modules are used but not imported', async() => {
+    const warnings = await linter.lint([`${ruleId}/forgot-import-before-fixes.html`]);
+    assert.deepEqual(warningPrinter.prettyPrint(warnings), [
+      `
+    <style include="iron-flex"></style>
+                   ~~~~~~~~~~~`,
+    ]);
+
+    assert.deepEqual(warnings.map((w) => w.message), [
+      `iron-flex-layout style modules are used but not imported.
+Import iron-flex-layout/iron-flex-layout-classes.html`,
+    ]);
+  });
+
+  test('adds missing import by inferring the base path', async() => {
+    const warnings = await linter.lint([`${ruleId}/forgot-import-before-fixes.html`]);
+    const edits = warnings.filter((w) => w.fix).map((w) => w.fix!);
+    const loader = makeParseLoader(analyzer);
+    const result = await applyEdits(edits, loader);
+    assert.deepEqual(
+        result.editedFiles.get(`${ruleId}/forgot-import-before-fixes.html`),
+        (await loader(`${ruleId}/forgot-import-after-fixes.html`)).contents);
+  });
+
+  test('adds missing import by defaulting the base path', async() => {
+    const warnings = await linter.lint([`${ruleId}/forgot-import-no-imports-before-fixes.html`]);
+    const edits = warnings.filter((w) => w.fix).map((w) => w.fix!);
+    const loader = makeParseLoader(analyzer);
+    const result = await applyEdits(edits, loader);
+    assert.deepEqual(
+        result.editedFiles.get(`${ruleId}/forgot-import-no-imports-before-fixes.html`),
+        (await loader(`${ruleId}/forgot-import-no-imports-after-fixes.html`)).contents);
+  });
+
+  test('warns when iron-flex-layout modules are imported but not used', async() => {
+    const warnings = await linter.lint([`${ruleId}/unnecessary-import-before-fixes.html`]);
+    assert.deepEqual(warningPrinter.prettyPrint(warnings), [
+      `
+<link rel="import" href="iron-flex-layout/iron-flex-layout-classes.html">
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~`,
+    ]);
+
+    assert.deepEqual(warnings.map((w) => w.message), [
+      `This import defines style modules that are not being used. Remove it.`,
+    ]);
+  });
+
+  test('removes unnecessary import', async() => {
+    const warnings = await linter.lint([`${ruleId}/unnecessary-import-before-fixes.html`]);
+    const edits = warnings.filter((w) => w.fix).map((w) => w.fix!);
+    const loader = makeParseLoader(analyzer);
+    const result = await applyEdits(edits, loader);
+    assert.deepEqual(
+        result.editedFiles.get(`${ruleId}/unnecessary-import-before-fixes.html`),
+        (await loader(`${ruleId}/unnecessary-import-after-fixes.html`)).contents);
   });
 });

--- a/src/test/polymer/iron-flex-layout-import_test.ts
+++ b/src/test/polymer/iron-flex-layout-import_test.ts
@@ -53,10 +53,10 @@ suite(ruleId, () => {
     ]);
 
     assert.deepEqual(warnings.map((w) => w.message), [
-      `./iron-flex-layout/classes/iron-flex-layout.html import is deprecated in iron-flex-layout v1, and not shipped in iron-flex-layout v2.x.
+      `./iron-flex-layout/classes/iron-flex-layout.html import is deprecated in iron-flex-layout v1, and not shipped in iron-flex-layout v2.
 Replace it with ./iron-flex-layout/iron-flex-layout-classes.html import.
 Run \`iron-flex-layout-classes\` to include the required style modules.`,
-      `./iron-flex-layout/classes/iron-shadow-flex-layout.html import is deprecated in iron-flex-layout v1, and not shipped in iron-flex-layout v2.x.
+      `./iron-flex-layout/classes/iron-shadow-flex-layout.html import is deprecated in iron-flex-layout v1, and not shipped in iron-flex-layout v2.
 Replace it with ./iron-flex-layout/iron-flex-layout-classes.html import.
 Run \`iron-flex-layout-classes\` to include the required style modules.`,
     ]);

--- a/src/test/polymer/iron-flex-layout-import_test.ts
+++ b/src/test/polymer/iron-flex-layout-import_test.ts
@@ -55,10 +55,10 @@ suite(ruleId, () => {
     assert.deepEqual(warnings.map((w) => w.message), [
       `./iron-flex-layout/classes/iron-flex-layout.html import is deprecated in iron-flex-layout v1, and not shipped in iron-flex-layout v2.
 Replace it with ./iron-flex-layout/iron-flex-layout-classes.html import.
-Run \`iron-flex-layout-classes\` to include the required style modules.`,
+Run the lint rule \`iron-flex-layout-classes\` with \`--fix\` to include the required style modules.`,
       `./iron-flex-layout/classes/iron-shadow-flex-layout.html import is deprecated in iron-flex-layout v1, and not shipped in iron-flex-layout v2.
 Replace it with ./iron-flex-layout/iron-flex-layout-classes.html import.
-Run \`iron-flex-layout-classes\` to include the required style modules.`,
+Run the lint rule \`iron-flex-layout-classes\` with \`--fix\` to include the required style modules.`,
     ]);
   });
 

--- a/test/iron-flex-layout-classes/after-fixes.html
+++ b/test/iron-flex-layout-classes/after-fixes.html
@@ -1,13 +1,74 @@
-<link rel="import" href="./iron-flex-layout/iron-flex-layout-classes.html">
-
-<dom-module id="my-el">
+<dom-module id="no-style">
   <template>
     <style include="iron-flex iron-flex-reverse iron-flex-alignment iron-flex-factors iron-positioning"></style>
-    <div class="layout horizontal">my el</div>
+    <div class="layout horizontal">
+      <p>lorem</p>
+      <p>ipsum</p>
+    </div>
   </template>
   <script>
     Polymer({
-      is: "my-el"
+      is: "no-style"
+    });
+  </script>
+</dom-module>
+
+
+<dom-module id="with-style">
+  <template>
+    <style include="iron-flex iron-flex-reverse iron-flex-alignment iron-flex-factors iron-positioning">
+       :host {
+        display: block;
+      }
+    </style>
+    <div class="layout horizontal">
+      <p>lorem</p>
+      <p>ipsum</p>
+    </div>
+  </template>
+  <script>
+    Polymer({
+      is: "with-style"
+    });
+  </script>
+</dom-module>
+
+
+<dom-module id="with-style-include">
+  <template>
+    <style include="awesome-style-module iron-flex iron-flex-reverse iron-flex-alignment iron-flex-factors iron-positioning">
+       :host {
+        display: block;
+      }
+    </style>
+    <div class="layout horizontal">
+      <p>lorem</p>
+      <p>ipsum</p>
+    </div>
+  </template>
+  <script>
+    Polymer({
+      is: "with-style-include"
+    });
+  </script>
+</dom-module>
+
+
+<dom-module id="with-partial-iron-flex-include">
+  <template>
+    <style include="awesome-style-module iron-flex iron-flex-reverse iron-flex-alignment iron-flex-factors iron-positioning">
+       :host {
+        display: block;
+      }
+    </style>
+    <div class="layout horizontal-reverse">
+      <p>lorem</p>
+      <p>ipsum</p>
+    </div>
+  </template>
+  <script>
+    Polymer({
+      is: "with-partial-iron-flex-include"
     });
   </script>
 </dom-module>

--- a/test/iron-flex-layout-classes/after-fixes.html
+++ b/test/iron-flex-layout-classes/after-fixes.html
@@ -112,7 +112,27 @@
     </template>
     <script>
       Polymer({
-        is: "with-style"
+        is: "with-style-outside"
+      });
+    </script>
+  </dom-module>
+
+
+  <dom-module id="with-right-include">
+    <template>
+      <style include="iron-flex">
+         :host {
+          display: block;
+        }
+      </style>
+      <div class="flex">
+        <p>lorem</p>
+        <p>ipsum</p>
+      </div>
+    </template>
+    <script>
+      Polymer({
+        is: "with-right-include"
       });
     </script>
   </dom-module>

--- a/test/iron-flex-layout-classes/after-fixes.html
+++ b/test/iron-flex-layout-classes/after-fixes.html
@@ -97,6 +97,26 @@
     </script>
   </dom-module>
 
+
+  <dom-module id="with-style-outside">
+    <style>
+       :host {
+        display: block;
+      }
+    </style>
+    <template>
+      <div class="layout horizontal">
+        <p>lorem</p>
+        <p>ipsum</p>
+      </div>
+    </template>
+    <script>
+      Polymer({
+        is: "with-style"
+      });
+    </script>
+  </dom-module>
+
 </body>
 
 </html>

--- a/test/iron-flex-layout-classes/after-fixes.html
+++ b/test/iron-flex-layout-classes/after-fixes.html
@@ -1,3 +1,18 @@
+<dom-module id="no-style-no-layout">
+  <template>
+    <div>
+      <p>lorem</p>
+      <p>ipsum</p>
+    </div>
+  </template>
+  <script>
+    Polymer({
+      is: "no-style-no-layout"
+    });
+  </script>
+</dom-module>
+
+
 <dom-module id="no-style">
   <template>
     <style include="iron-flex iron-flex-reverse iron-flex-alignment iron-flex-factors iron-positioning"></style>

--- a/test/iron-flex-layout-classes/after-fixes.html
+++ b/test/iron-flex-layout-classes/after-fixes.html
@@ -49,7 +49,7 @@
         }
       </style>
       <div class="layout horizontal">
-        <p>lorem</p>
+        <p class="flex">lorem</p>
         <p>ipsum</p>
       </div>
     </template>

--- a/test/iron-flex-layout-classes/after-fixes.html
+++ b/test/iron-flex-layout-classes/after-fixes.html
@@ -1,10 +1,14 @@
 <html>
 
+<head>
+  <style is="custom-style" include="iron-flex"></style>
+</head>
+
 <body class="fullbleed">
   <custom-style>
     <style is="custom-style" include="iron-positioning"></style>
   </custom-style>
-  <p>main doc</p>
+  <p class="flex">main doc</p>
 
   <dom-module id="no-classes">
     <template>

--- a/test/iron-flex-layout-classes/after-fixes.html
+++ b/test/iron-flex-layout-classes/after-fixes.html
@@ -141,6 +141,26 @@
     </script>
   </dom-module>
 
+
+  <dom-module id="with-inner-template">
+    <template>
+      <style include="iron-flex"></style>
+      <iron-list>
+        <template>
+          <div class="layout horizontal">
+            <p>lorem</p>
+            <p>ipsum</p>
+          </div>
+        </template>
+      </iron-list>
+    </template>
+    <script>
+      Polymer({
+        is: "with-inner-template"
+      });
+    </script>
+  </dom-module>
+
 </body>
 
 </html>

--- a/test/iron-flex-layout-classes/after-fixes.html
+++ b/test/iron-flex-layout-classes/after-fixes.html
@@ -1,13 +1,10 @@
 <html>
 
 <head>
-  <style is="custom-style" include="iron-flex"></style>
+  <style is="custom-style" include="iron-flex iron-positioning"></style>
 </head>
 
 <body class="fullbleed">
-  <custom-style>
-    <style is="custom-style" include="iron-positioning"></style>
-  </custom-style>
   <p class="flex">main doc</p>
 
   <dom-module id="no-classes">

--- a/test/iron-flex-layout-classes/after-fixes.html
+++ b/test/iron-flex-layout-classes/after-fixes.html
@@ -1,0 +1,13 @@
+<link rel="import" href="./iron-flex-layout/iron-flex-layout-classes.html">
+
+<dom-module id="my-el">
+  <template>
+    <style include="iron-flex iron-flex-reverse iron-flex-alignment iron-flex-factors iron-positioning"></style>
+    <div class="layout horizontal">my el</div>
+  </template>
+  <script>
+    Polymer({
+      is: "my-el"
+    });
+  </script>
+</dom-module>

--- a/test/iron-flex-layout-classes/after-fixes.html
+++ b/test/iron-flex-layout-classes/after-fixes.html
@@ -1,89 +1,101 @@
-<dom-module id="no-classes">
-  <template>
-    <div>
-      <p>lorem</p>
-      <p>ipsum</p>
-    </div>
-  </template>
-  <script>
-    Polymer({
-      is: "no-classes"
-    });
-  </script>
-</dom-module>
+<html>
+
+<body class="fullbleed">
+  <custom-style>
+    <style is="custom-style" include="iron-positioning"></style>
+  </custom-style>
+  <p>main doc</p>
+
+  <dom-module id="no-classes">
+    <template>
+      <div>
+        <p>lorem</p>
+        <p>ipsum</p>
+      </div>
+    </template>
+    <script>
+      Polymer({
+        is: "no-classes"
+      });
+    </script>
+  </dom-module>
 
 
-<dom-module id="no-style">
-  <template>
-    <style include="iron-flex"></style>
-    <div class="layout horizontal">
-      <p>lorem</p>
-      <p>ipsum</p>
-    </div>
-  </template>
-  <script>
-    Polymer({
-      is: "no-style"
-    });
-  </script>
-</dom-module>
+  <dom-module id="no-style">
+    <template>
+      <style include="iron-flex"></style>
+      <div class="layout horizontal">
+        <p>lorem</p>
+        <p>ipsum</p>
+      </div>
+    </template>
+    <script>
+      Polymer({
+        is: "no-style"
+      });
+    </script>
+  </dom-module>
 
 
-<dom-module id="with-style">
-  <template>
-    <style include="iron-flex">
-       :host {
-        display: block;
-      }
-    </style>
-    <div class="layout horizontal">
-      <p>lorem</p>
-      <p>ipsum</p>
-    </div>
-  </template>
-  <script>
-    Polymer({
-      is: "with-style"
-    });
-  </script>
-</dom-module>
+  <dom-module id="with-style">
+    <template>
+      <style include="iron-flex">
+         :host {
+          display: block;
+        }
+      </style>
+      <div class="layout horizontal">
+        <p>lorem</p>
+        <p>ipsum</p>
+      </div>
+    </template>
+    <script>
+      Polymer({
+        is: "with-style"
+      });
+    </script>
+  </dom-module>
 
 
-<dom-module id="with-include">
-  <template>
-    <style include="awesome-style iron-flex">
-       :host {
-        display: block;
-      }
-    </style>
-    <div class="layout horizontal">
-      <p>lorem</p>
-      <p>ipsum</p>
-    </div>
-  </template>
-  <script>
-    Polymer({
-      is: "with-include"
-    });
-  </script>
-</dom-module>
+  <dom-module id="with-include">
+    <template>
+      <style include="awesome-style iron-flex">
+         :host {
+          display: block;
+        }
+      </style>
+      <div class="layout horizontal">
+        <p>lorem</p>
+        <p>ipsum</p>
+      </div>
+    </template>
+    <script>
+      Polymer({
+        is: "with-include"
+      });
+    </script>
+  </dom-module>
 
 
-<dom-module id="with-partial-include">
-  <template>
-    <style include="awesome-style iron-flex iron-flex-reverse iron-flex-factors">
-       :host {
-        display: block;
-      }
-    </style>
-    <div class="layout horizontal-reverse">
-      <p class="layout vertical">lorem</p>
-      <p class="flex-1">ipsum</p>
-    </div>
-  </template>
-  <script>
-    Polymer({
-      is: "with-partial-include"
-    });
-  </script>
-</dom-module>
+  <dom-module id="with-partial-include">
+    <template>
+      <style include="awesome-style iron-flex iron-flex-reverse iron-flex-factors">
+         :host {
+          display: block;
+        }
+      </style>
+      <div class="layout horizontal-reverse">
+        <p class="layout vertical">lorem</p>
+        <p class="flex-1">ipsum</p>
+      </div>
+    </template>
+    <script>
+      Polymer({
+        is: "with-partial-include"
+      });
+    </script>
+  </dom-module>
+
+</body>
+
+</html>

--- a/test/iron-flex-layout-classes/after-fixes.html
+++ b/test/iron-flex-layout-classes/after-fixes.html
@@ -1,4 +1,4 @@
-<dom-module id="no-style-no-layout">
+<dom-module id="no-classes">
   <template>
     <div>
       <p>lorem</p>
@@ -7,7 +7,7 @@
   </template>
   <script>
     Polymer({
-      is: "no-style-no-layout"
+      is: "no-classes"
     });
   </script>
 </dom-module>
@@ -15,7 +15,7 @@
 
 <dom-module id="no-style">
   <template>
-    <style include="iron-flex iron-flex-reverse iron-flex-alignment iron-flex-factors iron-positioning"></style>
+    <style include="iron-flex"></style>
     <div class="layout horizontal">
       <p>lorem</p>
       <p>ipsum</p>
@@ -31,7 +31,7 @@
 
 <dom-module id="with-style">
   <template>
-    <style include="iron-flex iron-flex-reverse iron-flex-alignment iron-flex-factors iron-positioning">
+    <style include="iron-flex">
        :host {
         display: block;
       }
@@ -49,9 +49,9 @@
 </dom-module>
 
 
-<dom-module id="with-style-include">
+<dom-module id="with-include">
   <template>
-    <style include="awesome-style-module iron-flex iron-flex-reverse iron-flex-alignment iron-flex-factors iron-positioning">
+    <style include="awesome-style iron-flex">
        :host {
         display: block;
       }
@@ -63,27 +63,27 @@
   </template>
   <script>
     Polymer({
-      is: "with-style-include"
+      is: "with-include"
     });
   </script>
 </dom-module>
 
 
-<dom-module id="with-partial-iron-flex-include">
+<dom-module id="with-partial-include">
   <template>
-    <style include="awesome-style-module iron-flex iron-flex-reverse iron-flex-alignment iron-flex-factors iron-positioning">
+    <style include="awesome-style iron-flex iron-flex-reverse iron-flex-factors">
        :host {
         display: block;
       }
     </style>
     <div class="layout horizontal-reverse">
-      <p>lorem</p>
-      <p>ipsum</p>
+      <p class="layout vertical">lorem</p>
+      <p class="flex-1">ipsum</p>
     </div>
   </template>
   <script>
     Polymer({
-      is: "with-partial-iron-flex-include"
+      is: "with-partial-include"
     });
   </script>
 </dom-module>

--- a/test/iron-flex-layout-classes/after-fixes.html
+++ b/test/iron-flex-layout-classes/after-fixes.html
@@ -59,13 +59,13 @@
 
   <dom-module id="with-include">
     <template>
-      <style include="awesome-style iron-flex">
+      <style include="awesome-style iron-flex iron-flex-factors">
          :host {
           display: block;
         }
       </style>
-      <div class="layout horizontal">
-        <p>lorem</p>
+      <div class="flex">
+        <p class="flex-1">lorem</p>
         <p>ipsum</p>
       </div>
     </template>
@@ -79,7 +79,8 @@
 
   <dom-module id="with-partial-include">
     <template>
-      <style include="awesome-style iron-flex iron-flex-reverse iron-flex-factors">
+      <style include="awesome-style"></style>
+      <style include="iron-flex iron-flex-reverse iron-flex-factors">
          :host {
           display: block;
         }

--- a/test/iron-flex-layout-classes/before-fixes.html
+++ b/test/iron-flex-layout-classes/before-fixes.html
@@ -108,7 +108,27 @@
     </template>
     <script>
       Polymer({
-        is: "with-style"
+        is: "with-style-outside"
+      });
+    </script>
+  </dom-module>
+
+
+  <dom-module id="with-right-include">
+    <template>
+      <style include="iron-flex">
+         :host {
+          display: block;
+        }
+      </style>
+      <div class="flex">
+        <p>lorem</p>
+        <p>ipsum</p>
+      </div>
+    </template>
+    <script>
+      Polymer({
+        is: "with-right-include"
       });
     </script>
   </dom-module>

--- a/test/iron-flex-layout-classes/before-fixes.html
+++ b/test/iron-flex-layout-classes/before-fixes.html
@@ -1,3 +1,18 @@
+<dom-module id="no-style-no-layout">
+  <template>
+    <div>
+      <p>lorem</p>
+      <p>ipsum</p>
+    </div>
+  </template>
+  <script>
+    Polymer({
+      is: "no-style-no-layout"
+    });
+  </script>
+</dom-module>
+
+
 <dom-module id="no-style">
   <template>
     <div class="layout horizontal">

--- a/test/iron-flex-layout-classes/before-fixes.html
+++ b/test/iron-flex-layout-classes/before-fixes.html
@@ -1,7 +1,11 @@
 <html>
 
+<head>
+  <style is="custom-style" include="iron-flex"></style>
+</head>
+
 <body class="fullbleed">
-  <p>main doc</p>
+  <p class="flex">main doc</p>
 
   <dom-module id="no-classes">
     <template>

--- a/test/iron-flex-layout-classes/before-fixes.html
+++ b/test/iron-flex-layout-classes/before-fixes.html
@@ -45,7 +45,7 @@
         }
       </style>
       <div class="layout horizontal">
-        <p>lorem</p>
+        <p class="flex">lorem</p>
         <p>ipsum</p>
       </div>
     </template>

--- a/test/iron-flex-layout-classes/before-fixes.html
+++ b/test/iron-flex-layout-classes/before-fixes.html
@@ -60,8 +60,8 @@
           display: block;
         }
       </style>
-      <div class="layout horizontal">
-        <p>lorem</p>
+      <div class="flex">
+        <p class="flex-1">lorem</p>
         <p>ipsum</p>
       </div>
     </template>
@@ -75,7 +75,8 @@
 
   <dom-module id="with-partial-include">
     <template>
-      <style include="awesome-style iron-flex">
+      <style include="awesome-style"></style>
+      <style include="iron-flex">
          :host {
           display: block;
         }

--- a/test/iron-flex-layout-classes/before-fixes.html
+++ b/test/iron-flex-layout-classes/before-fixes.html
@@ -1,88 +1,97 @@
-<dom-module id="no-classes">
-  <template>
-    <div>
-      <p>lorem</p>
-      <p>ipsum</p>
-    </div>
-  </template>
-  <script>
-    Polymer({
-      is: "no-classes"
-    });
-  </script>
-</dom-module>
+<html>
+
+<body class="fullbleed">
+  <p>main doc</p>
+
+  <dom-module id="no-classes">
+    <template>
+      <div>
+        <p>lorem</p>
+        <p>ipsum</p>
+      </div>
+    </template>
+    <script>
+      Polymer({
+        is: "no-classes"
+      });
+    </script>
+  </dom-module>
 
 
-<dom-module id="no-style">
-  <template>
-    <div class="layout horizontal">
-      <p>lorem</p>
-      <p>ipsum</p>
-    </div>
-  </template>
-  <script>
-    Polymer({
-      is: "no-style"
-    });
-  </script>
-</dom-module>
+  <dom-module id="no-style">
+    <template>
+      <div class="layout horizontal">
+        <p>lorem</p>
+        <p>ipsum</p>
+      </div>
+    </template>
+    <script>
+      Polymer({
+        is: "no-style"
+      });
+    </script>
+  </dom-module>
 
 
-<dom-module id="with-style">
-  <template>
-    <style>
-       :host {
-        display: block;
-      }
-    </style>
-    <div class="layout horizontal">
-      <p>lorem</p>
-      <p>ipsum</p>
-    </div>
-  </template>
-  <script>
-    Polymer({
-      is: "with-style"
-    });
-  </script>
-</dom-module>
+  <dom-module id="with-style">
+    <template>
+      <style>
+         :host {
+          display: block;
+        }
+      </style>
+      <div class="layout horizontal">
+        <p>lorem</p>
+        <p>ipsum</p>
+      </div>
+    </template>
+    <script>
+      Polymer({
+        is: "with-style"
+      });
+    </script>
+  </dom-module>
 
 
-<dom-module id="with-include">
-  <template>
-    <style include="awesome-style">
-       :host {
-        display: block;
-      }
-    </style>
-    <div class="layout horizontal">
-      <p>lorem</p>
-      <p>ipsum</p>
-    </div>
-  </template>
-  <script>
-    Polymer({
-      is: "with-include"
-    });
-  </script>
-</dom-module>
+  <dom-module id="with-include">
+    <template>
+      <style include="awesome-style">
+         :host {
+          display: block;
+        }
+      </style>
+      <div class="layout horizontal">
+        <p>lorem</p>
+        <p>ipsum</p>
+      </div>
+    </template>
+    <script>
+      Polymer({
+        is: "with-include"
+      });
+    </script>
+  </dom-module>
 
 
-<dom-module id="with-partial-include">
-  <template>
-    <style include="awesome-style iron-flex">
-       :host {
-        display: block;
-      }
-    </style>
-    <div class="layout horizontal-reverse">
-      <p class="layout vertical">lorem</p>
-      <p class="flex-1">ipsum</p>
-    </div>
-  </template>
-  <script>
-    Polymer({
-      is: "with-partial-include"
-    });
-  </script>
-</dom-module>
+  <dom-module id="with-partial-include">
+    <template>
+      <style include="awesome-style iron-flex">
+         :host {
+          display: block;
+        }
+      </style>
+      <div class="layout horizontal-reverse">
+        <p class="layout vertical">lorem</p>
+        <p class="flex-1">ipsum</p>
+      </div>
+    </template>
+    <script>
+      Polymer({
+        is: "with-partial-include"
+      });
+    </script>
+  </dom-module>
+
+</body>
+
+</html>

--- a/test/iron-flex-layout-classes/before-fixes.html
+++ b/test/iron-flex-layout-classes/before-fixes.html
@@ -1,13 +1,73 @@
-<link rel="import" href="./iron-flex-layout/classes/iron-flex-layout.html">
-
-<dom-module id="my-el">
+<dom-module id="no-style">
   <template>
-    <style></style>
-    <div class="layout horizontal">my el</div>
+    <div class="layout horizontal">
+      <p>lorem</p>
+      <p>ipsum</p>
+    </div>
   </template>
   <script>
     Polymer({
-      is: "my-el"
+      is: "no-style"
+    });
+  </script>
+</dom-module>
+
+
+<dom-module id="with-style">
+  <template>
+    <style>
+       :host {
+        display: block;
+      }
+    </style>
+    <div class="layout horizontal">
+      <p>lorem</p>
+      <p>ipsum</p>
+    </div>
+  </template>
+  <script>
+    Polymer({
+      is: "with-style"
+    });
+  </script>
+</dom-module>
+
+
+<dom-module id="with-style-include">
+  <template>
+    <style include="awesome-style-module">
+       :host {
+        display: block;
+      }
+    </style>
+    <div class="layout horizontal">
+      <p>lorem</p>
+      <p>ipsum</p>
+    </div>
+  </template>
+  <script>
+    Polymer({
+      is: "with-style-include"
+    });
+  </script>
+</dom-module>
+
+
+<dom-module id="with-partial-iron-flex-include">
+  <template>
+    <style include="awesome-style-module iron-flex">
+       :host {
+        display: block;
+      }
+    </style>
+    <div class="layout horizontal-reverse">
+      <p>lorem</p>
+      <p>ipsum</p>
+    </div>
+  </template>
+  <script>
+    Polymer({
+      is: "with-partial-iron-flex-include"
     });
   </script>
 </dom-module>

--- a/test/iron-flex-layout-classes/before-fixes.html
+++ b/test/iron-flex-layout-classes/before-fixes.html
@@ -137,6 +137,25 @@
     </script>
   </dom-module>
 
+
+  <dom-module id="with-inner-template">
+    <template>
+      <iron-list>
+        <template>
+          <div class="layout horizontal">
+            <p>lorem</p>
+            <p>ipsum</p>
+          </div>
+        </template>
+      </iron-list>
+    </template>
+    <script>
+      Polymer({
+        is: "with-inner-template"
+      });
+    </script>
+  </dom-module>
+
 </body>
 
 </html>

--- a/test/iron-flex-layout-classes/before-fixes.html
+++ b/test/iron-flex-layout-classes/before-fixes.html
@@ -1,0 +1,13 @@
+<link rel="import" href="./iron-flex-layout/classes/iron-flex-layout.html">
+
+<dom-module id="my-el">
+  <template>
+    <style></style>
+    <div class="layout horizontal">my el</div>
+  </template>
+  <script>
+    Polymer({
+      is: "my-el"
+    });
+  </script>
+</dom-module>

--- a/test/iron-flex-layout-classes/before-fixes.html
+++ b/test/iron-flex-layout-classes/before-fixes.html
@@ -93,6 +93,26 @@
     </script>
   </dom-module>
 
+
+  <dom-module id="with-style-outside">
+    <style>
+       :host {
+        display: block;
+      }
+    </style>
+    <template>
+      <div class="layout horizontal">
+        <p>lorem</p>
+        <p>ipsum</p>
+      </div>
+    </template>
+    <script>
+      Polymer({
+        is: "with-style"
+      });
+    </script>
+  </dom-module>
+
 </body>
 
 </html>

--- a/test/iron-flex-layout-classes/before-fixes.html
+++ b/test/iron-flex-layout-classes/before-fixes.html
@@ -1,4 +1,4 @@
-<dom-module id="no-style-no-layout">
+<dom-module id="no-classes">
   <template>
     <div>
       <p>lorem</p>
@@ -7,7 +7,7 @@
   </template>
   <script>
     Polymer({
-      is: "no-style-no-layout"
+      is: "no-classes"
     });
   </script>
 </dom-module>
@@ -48,9 +48,9 @@
 </dom-module>
 
 
-<dom-module id="with-style-include">
+<dom-module id="with-include">
   <template>
-    <style include="awesome-style-module">
+    <style include="awesome-style">
        :host {
         display: block;
       }
@@ -62,27 +62,27 @@
   </template>
   <script>
     Polymer({
-      is: "with-style-include"
+      is: "with-include"
     });
   </script>
 </dom-module>
 
 
-<dom-module id="with-partial-iron-flex-include">
+<dom-module id="with-partial-include">
   <template>
-    <style include="awesome-style-module iron-flex">
+    <style include="awesome-style iron-flex">
        :host {
         display: block;
       }
     </style>
     <div class="layout horizontal-reverse">
-      <p>lorem</p>
-      <p>ipsum</p>
+      <p class="layout vertical">lorem</p>
+      <p class="flex-1">ipsum</p>
     </div>
   </template>
   <script>
     Polymer({
-      is: "with-partial-iron-flex-include"
+      is: "with-partial-include"
     });
   </script>
 </dom-module>

--- a/test/iron-flex-layout-import/after-fixes.html
+++ b/test/iron-flex-layout-import/after-fixes.html
@@ -1,1 +1,2 @@
 <link rel="import" href="./iron-flex-layout/iron-flex-layout-classes.html">
+<link rel="import" href="./iron-flex-layout/iron-flex-layout-classes.html">

--- a/test/iron-flex-layout-import/after-fixes.html
+++ b/test/iron-flex-layout-import/after-fixes.html
@@ -1,1 +1,0 @@
-<link rel="import" href="./iron-flex-layout/iron-flex-layout-classes.html">

--- a/test/iron-flex-layout-import/after-fixes.html
+++ b/test/iron-flex-layout-import/after-fixes.html
@@ -1,0 +1,1 @@
+<link rel="import" href="./iron-flex-layout/iron-flex-layout-classes.html">

--- a/test/iron-flex-layout-import/after-fixes.html
+++ b/test/iron-flex-layout-import/after-fixes.html
@@ -1,2 +1,1 @@
 <link rel="import" href="./iron-flex-layout/iron-flex-layout-classes.html">
-<link rel="import" href="./iron-flex-layout/iron-flex-layout-classes.html">

--- a/test/iron-flex-layout-import/before-fixes.html
+++ b/test/iron-flex-layout-import/before-fixes.html
@@ -1,0 +1,1 @@
+<link rel="import" href="./iron-flex-layout/classes/iron-flex-layout.html">

--- a/test/iron-flex-layout-import/before-fixes.html
+++ b/test/iron-flex-layout-import/before-fixes.html
@@ -1,2 +1,0 @@
-<link rel="import" href="./iron-flex-layout/classes/iron-flex-layout.html">
-<link rel="import" href="./iron-flex-layout/classes/iron-shadow-flex-layout.html">

--- a/test/iron-flex-layout-import/before-fixes.html
+++ b/test/iron-flex-layout-import/before-fixes.html
@@ -1,1 +1,2 @@
 <link rel="import" href="./iron-flex-layout/classes/iron-flex-layout.html">
+<link rel="import" href="./iron-flex-layout/classes/iron-shadow-flex-layout.html">

--- a/test/iron-flex-layout-import/deprecated-files-after-fixes.html
+++ b/test/iron-flex-layout-import/deprecated-files-after-fixes.html
@@ -1,0 +1,12 @@
+<link rel="import" href="./iron-flex-layout/iron-flex-layout-classes.html">
+<dom-module id="foo-bar">
+  <template>
+    <style include="iron-flex"></style>
+    <div class="flex"></div>
+  </template>
+  <script>
+    Polymer({
+      is: 'foo-bar'
+    });
+  </script>
+</dom-module>

--- a/test/iron-flex-layout-import/deprecated-files-before-fixes.html
+++ b/test/iron-flex-layout-import/deprecated-files-before-fixes.html
@@ -1,0 +1,13 @@
+<link rel="import" href="./iron-flex-layout/classes/iron-flex-layout.html">
+<link rel="import" href="./iron-flex-layout/classes/iron-shadow-flex-layout.html">
+<dom-module id="foo-bar">
+  <template>
+    <style include="iron-flex"></style>
+    <div class="flex"></div>
+  </template>
+  <script>
+    Polymer({
+      is: 'foo-bar'
+    });
+  </script>
+</dom-module>

--- a/test/iron-flex-layout-import/forgot-import-after-fixes.html
+++ b/test/iron-flex-layout-import/forgot-import-after-fixes.html
@@ -1,0 +1,7 @@
+<link rel="import" href="iron-flex-layout/iron-flex-layout.html">
+<link rel="import" href="iron-flex-layout/iron-flex-layout-classes.html">
+<dom-module id="foo-bar">
+  <template>
+    <style include="iron-flex"></style>
+  </template>
+</dom-module>

--- a/test/iron-flex-layout-import/forgot-import-before-fixes.html
+++ b/test/iron-flex-layout-import/forgot-import-before-fixes.html
@@ -1,0 +1,6 @@
+<link rel="import" href="iron-flex-layout/iron-flex-layout.html">
+<dom-module id="foo-bar">
+  <template>
+    <style include="iron-flex"></style>
+  </template>
+</dom-module>

--- a/test/iron-flex-layout-import/forgot-import-no-imports-after-fixes.html
+++ b/test/iron-flex-layout-import/forgot-import-no-imports-after-fixes.html
@@ -1,0 +1,6 @@
+<link rel="import" href="./iron-flex-layout/iron-flex-layout-classes.html">
+<dom-module id="foo-bar">
+  <template>
+    <style include="iron-flex"></style>
+  </template>
+</dom-module>

--- a/test/iron-flex-layout-import/forgot-import-no-imports-before-fixes.html
+++ b/test/iron-flex-layout-import/forgot-import-no-imports-before-fixes.html
@@ -1,0 +1,5 @@
+<dom-module id="foo-bar">
+  <template>
+    <style include="iron-flex"></style>
+  </template>
+</dom-module>

--- a/test/iron-flex-layout-import/unnecessary-import-after-fixes.html
+++ b/test/iron-flex-layout-import/unnecessary-import-after-fixes.html
@@ -1,0 +1,6 @@
+<link rel="import" href="iron-flex-layout/iron-flex-layout.html">
+<dom-module id="foo-bar">
+  <template>
+    <div>Hello!</div>
+  </template>
+</dom-module>

--- a/test/iron-flex-layout-import/unnecessary-import-before-fixes.html
+++ b/test/iron-flex-layout-import/unnecessary-import-before-fixes.html
@@ -1,0 +1,7 @@
+<link rel="import" href="iron-flex-layout/iron-flex-layout.html">
+<link rel="import" href="iron-flex-layout/iron-flex-layout-classes.html">
+<dom-module id="foo-bar">
+  <template>
+    <div>Hello!</div>
+  </template>
+</dom-module>

--- a/test/style-into-template/after-fixes.html
+++ b/test/style-into-template/after-fixes.html
@@ -59,3 +59,14 @@
     customElements.define('empty-style', class extends Polymer.Element {});
   </script>
 </dom-module>
+
+<dom-module id="bad-indent-style">
+
+  <template>
+    <style></style>
+    <div>Hello</div>
+  </template>
+  <script>
+    customElements.define('bad-indent-style', class extends Polymer.Element {});
+  </script>
+</dom-module>

--- a/test/style-into-template/before-fixes.html
+++ b/test/style-into-template/before-fixes.html
@@ -60,3 +60,14 @@
     customElements.define('empty-style', class extends Polymer.Element {});
   </script>
 </dom-module>
+
+<dom-module id="bad-indent-style">
+<style></style>
+
+  <template>
+    <div>Hello</div>
+  </template>
+  <script>
+    customElements.define('bad-indent-style', class extends Polymer.Element {});
+  </script>
+</dom-module>


### PR DESCRIPTION
 - [x] CHANGELOG.md has been updated

Introducing 2 new rules for iron-flex-layout upgrades.
[iron-flex-layout v2 doesn't ship anymore](https://github.com/PolymerElements/iron-flex-layout/#changes-in-20) the long time deprecated `iron-flex-layout/classes/*.html` files.
These files were using the now deprecated /deep/ selector, and were styling the main document from an html import (feature not supported anymore in Chrome). 

The upgrade guide - see [Removing /deep/ and :shadow section](https://www.polymer-project.org/blog/2017-10-18-upcoming-changes.html) - suggests to:
- rename the import
- import the style modules in the element's shadow root

This PR implements 2 new rules to help achieve these 2 tasks.

### Limitations

1) Elements might be importing `iron-flex-layout/iron-flex-layout.html` and define themselves classes like: 
```html
<link rel="import" href="../iron-flex-layout/iron-flex-layout.html">
<dom-module id="my-element">
  <template>
    <style>
      .flex { @apply --layout-flex; }
    </style>
    <div class="flex">
```
In these cases `iron-flex-layout-classes` will still add the `style include="iron-flex"`, which wouldn't break styles, but wouldn't either be needed, resulting in:
```html
<link rel="import" href="../iron-flex-layout/iron-flex-layout.html">
<dom-module id="my-element">
  <template>
    <style include="iron-flex">
      .flex { @apply --layout-flex; }
    </style>
    <div class="flex">
```

2) There is no warning if classes are used but `iron-flex-layout/iron-flex-layout-classes.html` import is missing. As there is no prescribed way to import dependencies, it might be that the classes definitions are imported through a common import, e.g.
```html
<link rel="import" href="./commons.html">
<dom-module id="my-element">
  <template>
    <style include="iron-flex"></style>
    <div class="flex">
```
with `commons.html` being:
```html
<link rel="import" href="../iron-flex-layout/iron-flex-layout-classes.html">
```
This could be done in a separate PR, but requires all imports in the file to be parseable and we'd require to know the base path where to find iron-flex-layout - could be computed if there is already an import with iron-flex-layout/* href.

### Possible improvements
- When `iron-flex-layout-classes` is run on a non-polymer file which uses iron-flex-layout classes, it will erroneously warn and apply fix. Need a way to figure if the document is using polymer or not - maybe check the dependencies? 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/polymer/polymer-linter/116)
<!-- Reviewable:end -->
