### PR TITLE
Add actions to warnings.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
+- Added a concept of edit actions, which are like fixes with caveats. These need explicit user intent to apply because they may change the code's API, or otherwise be unsafe.
 - Support warning about and automatically fixing some simple uses of some 1.0 elements to their 2.0 usage styles.
   - To add this fixable lint warning for your own elements, simply add the `old-content-selector` attribute to your new `<slot>` element. Set its value to the value that your old `<content>` element had for its `select` attribute.
     - e.g. if you had `<content select=".some-content">` and migrated to `<slot name="new-content" old-content-selector=".some-content">` then the linter will warn about and add `slot="new-content"` to children of your element that match `.some-content`.
-- Support warning about and automatically fixing element declarations that use `<content>` to use `<slot>` instead. This is a breaking change to an element,
-so it is not on by default.
+- Support warning about and automatically fixing/editing element declarations that use `<content>` to use `<slot>` instead.
   - It automatically adds the `old-content-selector` attribute to migrated `<slot>` elements, so uses can be automatically upgraded as well.
 - Support automatic fixing of the warning where a `<style>` element is a direct child of a dom-module's `<template>`.
 - Support warning about and fixing usage of deprecated `iron-flex-layout/classes/*` files via the new rule `iron-flex-layout-import`

--- a/src/collections.ts
+++ b/src/collections.ts
@@ -21,6 +21,7 @@ registry.register(
     new RuleCollection('polymer-2', `Rules for projects that use Polymer 2.x`, [
       'behaviors-spelling',
       'call-super-in-callbacks',
+      'content-to-slot-declarations',
       'content-to-slot-usages',
       'databind-with-unknown-property',
       'databinding-calls-must-be-functions',
@@ -40,6 +41,7 @@ registry.register(new RuleCollection(
 Will warn about use of deprecated Polymer 1.x features or brand new features in Polymer 2.x`,
     [
       'behaviors-spelling',
+      'content-to-slot-declarations',
       'content-to-slot-usages',
       'databinding-calls-must-be-functions',
       'databind-with-unknown-property',

--- a/src/css/deprecated-css-custom-property-syntax.ts
+++ b/src/css/deprecated-css-custom-property-syntax.ts
@@ -17,16 +17,14 @@ import * as shady from 'shady-css-parser';
 
 import {CssRule} from '../css/rule';
 import {registry} from '../registry';
+import {stripIndentation} from '../util';
 import {FixableWarning} from '../warning';
-
-import stripIndent = require('strip-indent');
-
 
 class DeprecatedCustomPropertySyntax extends CssRule {
   code = 'deprecated-css-custom-property-syntax';
-  description = stripIndent(`
+  description = stripIndentation(`
       Warns when using deprecated css syntax around CSS Custom Properties.
-  `).trim();
+  `);
 
   async checkDocument(parsedDocument: ParsedCssDocument, _document: Document) {
     const warnings: FixableWarning[] = [];

--- a/src/html/dom-module-name-or-is.ts
+++ b/src/html/dom-module-name-or-is.ts
@@ -17,17 +17,16 @@ import {ParsedHtmlDocument, Severity, Warning} from 'polymer-analyzer';
 
 import {registry} from '../registry';
 import {stripWhitespace} from '../util';
+import {stripIndentation} from '../util';
 
 import {HtmlRule} from './rule';
-
-import stripIndent = require('strip-indent');
 
 
 const p = dom5.predicates;
 
 class DomModuleNameOrIs extends HtmlRule {
   code = 'dom-module-invalid-attrs';
-  description = stripIndent(`
+  description = stripIndentation(`
       Warns for:
 
           <dom-module name="foo-elem">

--- a/src/html/move-style-into-template.ts
+++ b/src/html/move-style-into-template.ts
@@ -18,12 +18,11 @@ import * as parse5 from 'parse5';
 import {Document, ParsedHtmlDocument, Severity} from 'polymer-analyzer';
 
 import {registry} from '../registry';
+import {stripIndentation} from '../util';
 import {FixableWarning, Replacement} from '../warning';
 
 import {HtmlRule} from './rule';
 import {addIndentation, getIndentationInside, removeTrailingWhitespace} from './util';
-
-import stripIndent = require('strip-indent');
 
 const p = dom5.predicates;
 const styleMustBeInside = p.OR(
@@ -42,7 +41,7 @@ const mustBeOutsideTemplate =
 
 class MoveStyleIntoTemplate extends HtmlRule {
   code = 'style-into-template';
-  description = stripIndent(`
+  description = stripIndentation(`
       Warns about \`style\` tags in dom-modules but not in templates.
 
       This:

--- a/src/html/undefined-elements.ts
+++ b/src/html/undefined-elements.ts
@@ -15,16 +15,16 @@
 import {Document, ParsedHtmlDocument, Severity, Warning} from 'polymer-analyzer';
 
 import {registry} from '../registry';
+import {stripIndentation} from '../util';
 
 import {HtmlRule} from './rule';
 
-import stripIndent = require('strip-indent');
 
 class UndefinedElements extends HtmlRule {
   code = 'undefined-elements';
-  description = stripIndent(`
+  description = stripIndentation(`
     Warns when an HTML tag refers to a custom element with no known definition.
-  `).trim();
+  `);
 
   async checkDocument(parsedDocument: ParsedHtmlDocument, document: Document):
       Promise<Warning[]> {

--- a/src/polymer/behaviors-spelling.ts
+++ b/src/polymer/behaviors-spelling.ts
@@ -18,12 +18,12 @@ import {registry} from '../registry';
 import {Rule} from '../rule';
 import {stripWhitespace} from '../util';
 
-import stripIndent = require('strip-indent');
+import {stripIndentation} from '../util';
 
 
 class BehaviorsSpelling extends Rule {
   code = 'behaviors-spelling';
-  description = stripIndent(`
+  description = stripIndentation(`
       Warns when the Polymer \`behaviors\` property is spelled \`behaviours\`,
       as Polymer uses the American spelling.
 
@@ -36,7 +36,7 @@ class BehaviorsSpelling extends Rule {
           Polymer({
             behaviors: [...]
           });
-  `).trim();
+  `);
 
   async check(document: Document) {
     const warnings: Warning[] = [];

--- a/src/polymer/call-super-in-callbacks.ts
+++ b/src/polymer/call-super-in-callbacks.ts
@@ -20,7 +20,7 @@ import {registry} from '../registry';
 import {Rule} from '../rule';
 import {stripWhitespace} from '../util';
 
-import stripIndent = require('strip-indent');
+import {stripIndentation} from '../util';
 
 const methodsThatMustCallSuper = new Set([
   'ready',
@@ -31,10 +31,10 @@ const methodsThatMustCallSuper = new Set([
 
 class CallSuperInCallbacks extends Rule {
   code = 'call-super-in-callbacks';
-  description = stripIndent(`
+  description = stripIndentation(`
       Warns when a Polymer element overrides one of the custom element callbacks
       but does not call super.callbackName().
-  `).trim();
+  `);
 
   async check(document: Document) {
     const warnings: Warning[] = [];

--- a/src/polymer/content-to-slot-usages.ts
+++ b/src/polymer/content-to-slot-usages.ts
@@ -18,17 +18,16 @@ import {treeAdapters} from 'parse5';
 import {Document, Element, ParsedHtmlDocument, Severity, Slot} from 'polymer-analyzer';
 
 import {HtmlRule} from '../html/rule';
-import {registry} from '../registry';
-import {FixableWarning, Replacement} from '../warning';
-
-import stripIndent = require('strip-indent');
 import {elementSelectorToPredicate} from '../html/util';
+import {registry} from '../registry';
+import {stripIndentation} from '../util';
+import {FixableWarning, Replacement} from '../warning';
 
 class ContentToSlot extends HtmlRule {
   code = 'content-to-slot-usages';
-  description = stripIndent(`
+  description = stripIndentation(`
       Warns when an element should have a \`slot\` attribute but does not.
-    `).trim();
+  `);
 
   async checkDocument(parsedDocument: ParsedHtmlDocument, document: Document) {
     const warnings: FixableWarning[] = [];

--- a/src/polymer/databind-with-unknown-property.ts
+++ b/src/polymer/databind-with-unknown-property.ts
@@ -20,7 +20,7 @@ import {sharedProperties} from '../html/util';
 import {registry} from '../registry';
 import {closestSpelling} from '../util';
 
-import stripIndent = require('strip-indent');
+import {stripIndentation} from '../util';
 
 const p = dom5.predicates;
 const isDomRepeat = p.OR(
@@ -29,9 +29,9 @@ const isDomRepeat = p.OR(
 
 class DatabindWithUnknownProperty extends HtmlRule {
   code = 'databind-with-unknown-property';
-  description = stripIndent(`
+  description = stripIndentation(`
       Warns when a polymer databinding expression uses an undeclared property.
-  `).trim();
+  `);
 
   async checkDocument(parsedDocument: ParsedHtmlDocument, document: Document) {
     const warnings: Warning[] = [];

--- a/src/polymer/databinding-calls-must-be-functions.ts
+++ b/src/polymer/databinding-calls-must-be-functions.ts
@@ -14,17 +14,16 @@
 
 import {Document, Severity, Warning} from 'polymer-analyzer';
 
-import stripIndent = require('strip-indent');
-import {stripWhitespace} from '../util';
-import {Rule} from '../rule';
 import {registry} from '../registry';
+import {Rule} from '../rule';
+import {stripIndentation, stripWhitespace} from '../util';
 
 const definitelyNotMethodTypes =
     new Set(['string', 'number', 'boolean', 'Array']);
 
 class DatabindingCallsMustBeFunctions extends Rule {
   code = 'databinding-calls-must-be-functions';
-  description = stripIndent(`
+  description = stripIndentation(`
       Warns when a property in a Polymer databinding is called but it isn't
       a function property on the element.
 
@@ -51,7 +50,7 @@ class DatabindingCallsMustBeFunctions extends Rule {
             },
             foo(bar) { /* ... */}
           });
-  `).trim();
+  `);
 
   async check(document: Document) {
     const warnings: Warning[] = [];

--- a/src/polymer/element-before-dom-module.ts
+++ b/src/polymer/element-before-dom-module.ts
@@ -15,8 +15,7 @@ import {comparePositionAndRange, Document, DomModule, ParsedHtmlDocument, Severi
 
 import {HtmlRule} from '../html/rule';
 import {registry} from '../registry';
-
-import stripIndent = require('strip-indent');
+import {stripIndentation} from '../util';
 
 /**
  * Unbalanced binding expression delimiters occurs when a value such as
@@ -25,7 +24,7 @@ import stripIndent = require('strip-indent');
  */
 class ElementBeforeDomModule extends HtmlRule {
   readonly code = 'element-before-dom-module';
-  readonly description = stripIndent(`
+  readonly description = stripIndentation(`
       Warns for an element being declared before its dom-module.
 
       For example, this is invalid:
@@ -35,7 +34,7 @@ class ElementBeforeDomModule extends HtmlRule {
       But this is fine:
         <dom-module id='my-elem'></dom-module>
         <script>Polymer({is: 'my-elem'})</script>
-      `).trim();
+  `);
 
   public async checkDocument(
       parsedHtml: ParsedHtmlDocument, document: Document): Promise<Warning[]> {

--- a/src/polymer/elements/iron-flex-layout-classes.ts
+++ b/src/polymer/elements/iron-flex-layout-classes.ts
@@ -17,12 +17,10 @@ import {treeAdapters} from 'parse5';
 import {Document, ParsedHtmlDocument, Severity} from 'polymer-analyzer';
 
 import {HtmlRule} from '../../html/rule';
+import {addAttribute, elementSelectorToPredicate, getIndentationInside, prependContentInto} from '../../html/util';
 import {registry} from '../../registry';
+import {stripIndentation} from '../../util';
 import {FixableWarning} from '../../warning';
-
-import stripIndent = require('strip-indent');
-
-import {elementSelectorToPredicate, getIndentationInside, addAttribute, prependContentInto} from '../../html/util';
 
 const p = dom5.predicates;
 
@@ -73,7 +71,7 @@ const isStyleInclude = p.AND(p.hasTagName('style'), p.hasAttr('include'));
 
 class IronFlexLayoutClasses extends HtmlRule {
   code = 'iron-flex-layout-classes';
-  description = stripIndent(`
+  description = stripIndentation(`
       Warns when iron-flex-layout classes are used without including the style modules.
 
       This:
@@ -99,7 +97,7 @@ class IronFlexLayoutClasses extends HtmlRule {
               <div class="layout vertical">hello</div>
             </template>
           <dom-module>
-  `).trim();
+  `);
 
   async checkDocument(parsedDocument: ParsedHtmlDocument, document: Document) {
     const warnings: FixableWarning[] = [];

--- a/src/polymer/elements/iron-flex-layout-import.ts
+++ b/src/polymer/elements/iron-flex-layout-import.ts
@@ -18,9 +18,8 @@ import {Document, ParsedHtmlDocument, Severity} from 'polymer-analyzer';
 import {HtmlRule} from '../../html/rule';
 import {getIndentationInside, insertContentAfter, removeNode} from '../../html/util';
 import {registry} from '../../registry';
+import {stripIndentation} from '../../util';
 import {FixableWarning, Replacement} from '../../warning';
-
-import stripIndent = require('strip-indent');
 
 // Capture any import file in the `classes` folder.
 const deprecatedImports = /iron-flex-layout\/classes\/.*/;
@@ -41,7 +40,7 @@ const usesIronFlexStyleIncludes = p.AND(
 
 class IronFlexLayoutImport extends HtmlRule {
   code = 'iron-flex-layout-import';
-  description = stripIndent(`
+  description = stripIndentation(`
       Warns when the deprecated iron-flex-layout/classes/*.html files are imported.
 
       This:
@@ -52,7 +51,7 @@ class IronFlexLayoutImport extends HtmlRule {
       Should instead be written as:
 
           <link rel="import" href="../iron-flex-layout/iron-flex-layout-classes.html">
-  `).trim();
+  `);
 
   async checkDocument(parsedDocument: ParsedHtmlDocument, document: Document) {
     const warnings: FixableWarning[] = [];

--- a/src/polymer/set-unknown-attribute.ts
+++ b/src/polymer/set-unknown-attribute.ts
@@ -18,15 +18,14 @@ import {Attribute, Document, Element, isPositionInsideRange, ParsedHtmlDocument,
 import {HtmlRule} from '../html/rule';
 import {sharedAttributes, sharedProperties} from '../html/util';
 import {registry} from '../registry';
-import {closestSpelling, stripWhitespace} from '../util';
+import {closestSpelling, stripIndentation, stripWhitespace} from '../util';
 
-import stripIndent = require('strip-indent');
 import {isDatabindingTemplate} from './matchers';
 
 
 class SetUnknownAttribute extends HtmlRule {
   code = 'set-unknown-attribute';
-  description = stripIndent(`
+  description = stripIndentation(`
       Warns when setting undeclared properties or attributes in HTML.
 
       This rule will check use of attributes in HTML on custom elements, as well
@@ -38,7 +37,7 @@ class SetUnknownAttribute extends HtmlRule {
 
       Currently only checks custom elements, as we don't yet have the necessary
       metadata on native elements in a convenient format.
-  `).trim();
+  `);
 
   async checkDocument(parsedDoc: ParsedHtmlDocument, document: Document) {
     const warnings: Warning[] = [];

--- a/src/polymer/unbalanced-delimiters.ts
+++ b/src/polymer/unbalanced-delimiters.ts
@@ -18,10 +18,9 @@ import {ParsedHtmlDocument, Severity, Warning} from 'polymer-analyzer';
 
 import {HtmlRule} from '../html/rule';
 import {registry} from '../registry';
+import {stripIndentation} from '../util';
 
 import * as matchers from './matchers';
-
-import stripIndent = require('strip-indent');
 
 /**
  * Unbalanced binding expression delimiters occurs when a value such as
@@ -30,11 +29,12 @@ import stripIndent = require('strip-indent');
  */
 class UnbalancedDelimiters extends HtmlRule {
   code = 'unbalanced-polymer-delimiters';
-  description = stripIndent(`
+  description = stripIndentation(`
       Matches unbalanced delimiters around Polymer databinding expressions.
 
       For example, {{foo} is missing a } at the end, it should instead be
-      {{foo}}.`);
+      {{foo}}.
+  `);
 
   public async checkDocument(parsedHtml: ParsedHtmlDocument):
       Promise<Warning[]> {

--- a/src/test/polymer/content-to-slot-declarations_test.ts
+++ b/src/test/polymer/content-to-slot-declarations_test.ts
@@ -47,4 +47,24 @@ suite(ruleId, () => {
         result.editedFiles.get(`${ruleId}/before-fixes.html`),
         (await loader(`${ruleId}/after-fixes.html`)).contents);
   });
+
+  test('applies fixes and edit actions', async() => {
+    const warnings = await linter.lint([`${ruleId}/before-fixes.html`]);
+    const edits = [];
+    for (const warning of warnings) {
+      if (warning.fix) {
+        edits.push(warning.fix);
+      }
+      for (const action of warning.actions || []) {
+        if (action.kind === 'edit') {
+          edits.push(action.edit);
+        }
+      }
+    }
+    const loader = makeParseLoader(analyzer);
+    const result = await applyEdits(edits, loader);
+    assert.deepEqual(
+        result.editedFiles.get(`${ruleId}/before-fixes.html`),
+        (await loader(`${ruleId}/after-edits.html`)).contents);
+  });
 });

--- a/src/util.ts
+++ b/src/util.ts
@@ -14,6 +14,8 @@
 
 import * as levenshtein from 'fast-levenshtein';
 
+import stripIndent = require('strip-indent');
+
 /**
  * A utility for more easily writing long strings inline in code.
  *
@@ -30,6 +32,24 @@ import * as levenshtein from 'fast-levenshtein';
 export function stripWhitespace(str: string) {
   return str.trim().replace(/\s*\n\s*/g, ' ');
 };
+
+/**
+ * A utility for writing long multiline strings inline in code.
+ *
+ * Determines the initial indentation based on the first indented line,
+ * and removes it from all other lines, then trims off leading and trailing
+ * whitespace. Use like:
+ *
+ *     stripIndentation(`
+ *         hello
+ *           world
+ *     `);
+ *
+ * This evaluates to "hello\n  world"
+ */
+export function stripIndentation(str: string) {
+  return stripIndent(str).trim();
+}
 
 export function minBy<T>(it: Iterable<T>, score: (t: T) => number) {
   let min = undefined;

--- a/src/warning.ts
+++ b/src/warning.ts
@@ -31,6 +31,36 @@ export class FixableWarning extends Warning {
    * issue completely then it should go in `fix`.
    */
   fix?: Edit;
+
+
+  actions?: Action[];
+}
+
+export type Action = EditAction;
+
+/**
+ * An EditAction is like a fix, only it's not applied automatically when the
+ * user runs `polymer lint --fix`. Often this is because it's less safe to
+ * apply automatically, and there may be caveats, or multiple ways to resolve
+ * the warning.
+ *
+ * For example, a change to an element that updates it to no longer use a
+ * deprecated feature, but that involves a change in the element's API should
+ * not be a fix, but should instead be an EditAction.
+ */
+export interface EditAction {
+  kind: 'edit';
+  /**
+   * A unique string code for the edit action. Useful so that the user can
+   * request that all actions with a given code should be applied.
+   */
+  code: string;
+  /**
+   * A short description of the change, noting caveats and important information
+   * for the user.
+   */
+  description: string;
+  edit: Edit;
 }
 
 /**

--- a/test/content-to-slot-declarations/after-edits.html
+++ b/test/content-to-slot-declarations/after-edits.html
@@ -1,8 +1,8 @@
 <dom-module id="foo-bar">
   <template>
-    <content select=".foo" existing-nonsense-attribute="bar">
+    <slot name="foo" existing-nonsense-attribute="bar" old-content-selector=".foo">
       Fallback content here
-    </content>
+    </slot>
     <slot></slot>
   </template>
   <script>
@@ -14,9 +14,9 @@
 
 <dom-module id="baz-bing">
   <template>
-    <content select=".foo"></content>
-    <content select="[foo]"></content>
-    <content select="#foo"></content>
+    <slot name="foo" old-content-selector=".foo"></slot>
+    <slot name="foo-unique-suffix" old-content-selector="[foo]"></slot>
+    <slot name="foo-unique-suffix-unique-suffix" old-content-selector="#foo"></slot>
   </template>
   <script>
     Polymer({


### PR DESCRIPTION
This represents more general actions that could be applied to address warnings. The first action kind is an edit, which is like a fix with caveats, and which needs an indication of specific user intent to apply.

This change also adds content-to-slot-declarations as a default rule, using edit actions to delineate changes which are safe from those that aren't.

<!--
  Thanks for the PR!

  If this change has a user visible change (including
  bug fixes, new features, etc) please describe the change in
  CHANGELOG.md.

  If the change is an entirely package-internal reshuffling/refactoring
  should the change not be described in the CHANGELOG.

  Consider also updating the README.

  More info: http://keepachangelog.com/en/0.3.0/
 -->

 - [x] CHANGELOG.md has been updated

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/polymer/polymer-linter/122)
<!-- Reviewable:end -->
