### PR TITLE
update, delete or add iron-flex-layout-classes import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 so it is not on by default.
   - It automatically adds the `old-content-selector` attribute to migrated `<slot>` elements, so uses can be automatically upgraded as well.
 - Support automatic fixing of the warning where a `<style>` element is a direct child of a dom-module's `<template>`.
-- Support warning about and fixing usage of deprecated `iron-flex-layout/classes/*.html` files via the new rule `iron-flex-layout-import`
-  - It automatically upgrades to import the `iron-flex-layout/iron-flex-layout-classes.html` instead.
+- Support warning about and fixing usage of deprecated `iron-flex-layout/classes/*` files via the new rule `iron-flex-layout-import`
+  - It automatically adds, updates, or deletes the import `iron-flex-layout/iron-flex-layout-classes.html`.
 - Support warning about and fixing usage of iron-flex-layout classes without including the required style modules via the new rule `iron-flex-layout-classes`
   - It automatically upgrades the element template to include the iron-flex-layout style modules.
 

--- a/src/polymer/elements/iron-flex-layout-classes.ts
+++ b/src/polymer/elements/iron-flex-layout-classes.ts
@@ -16,13 +16,13 @@ import * as dom5 from 'dom5';
 import {treeAdapters} from 'parse5';
 import {Document, ParsedHtmlDocument, Severity} from 'polymer-analyzer';
 
-import {HtmlRule} from '../html/rule';
-import {registry} from '../registry';
-import {FixableWarning} from '../warning';
+import {HtmlRule} from '../../html/rule';
+import {registry} from '../../registry';
+import {FixableWarning} from '../../warning';
 
 import stripIndent = require('strip-indent');
 
-import {elementSelectorToPredicate, getIndentationInside, addAttribute, prependContentInto} from '../html/util';
+import {elementSelectorToPredicate, getIndentationInside, addAttribute, prependContentInto} from '../../html/util';
 
 const p = dom5.predicates;
 

--- a/src/polymer/elements/rules.ts
+++ b/src/polymer/elements/rules.ts
@@ -1,0 +1,16 @@
+/**
+ * @license
+ * Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at
+ * http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at
+ * http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+import './iron-flex-layout-classes';
+import './iron-flex-layout-import';

--- a/src/polymer/iron-flex-layout-classes.ts
+++ b/src/polymer/iron-flex-layout-classes.ts
@@ -18,11 +18,11 @@ import {Document, ParsedHtmlDocument, Severity} from 'polymer-analyzer';
 
 import {HtmlRule} from '../html/rule';
 import {registry} from '../registry';
-import {FixableWarning, Replacement} from '../warning';
+import {FixableWarning} from '../warning';
 
 import stripIndent = require('strip-indent');
 
-import {elementSelectorToPredicate, getIndentationInside} from '../html/util';
+import {elementSelectorToPredicate, getIndentationInside, addAttribute, prependContentInto} from '../html/util';
 
 const p = dom5.predicates;
 
@@ -137,7 +137,7 @@ class IronFlexLayoutClasses extends HtmlRule {
           dom5.query(templateContent, p.hasTagName('style'));
       if (!styleNode) {
         const indent = getIndentationInside(templateContent);
-        warning.fix = [prependContent(parsedDocument, template, `
+        warning.fix = [prependContentInto(parsedDocument, template, `
 ${indent}<style include="${missingModules}"></style>`)];
       } else if (dom5.hasAttribute(styleNode, 'include')) {
         const include = dom5.getAttribute(styleNode, 'include')!;
@@ -176,7 +176,7 @@ ${indent}<style include="${missingModules}"></style>`)];
       }];
     } else {
       const indent = getIndentationInside(body);
-      warning.fix = [prependContent(parsedDocument, body, `
+      warning.fix = [prependContentInto(parsedDocument, body, `
 ${indent}<custom-style>
 ${indent}  <style is="custom-style" include="${missingModules}"></style>
 ${indent}</custom-style>`)];
@@ -253,34 +253,6 @@ function getStyleNodeWithInclude(node: dom5.Node) {
     }
   }
   return styleToEdit;
-}
-
-function addAttribute(
-    parsedDocument: ParsedHtmlDocument,
-    node: dom5.Node,
-    attribute: string,
-    attributeValue: string): Replacement {
-  const tagRange = parsedDocument.sourceRangeForStartTag(node)!;
-  const range = {
-    file: tagRange.file,
-    start: {line: tagRange.end.line, column: tagRange.end.column - 1},
-    end: {line: tagRange.end.line, column: tagRange.end.column - 1}
-  };
-  const replacementText = ` ${attribute}="${attributeValue}"`;
-  return {replacementText, range};
-}
-
-function prependContent(
-    parsedDocument: ParsedHtmlDocument,
-    node: dom5.Node,
-    replacementText: string): Replacement {
-  const tagRange = parsedDocument.sourceRangeForStartTag(node)!;
-  const range = {
-    file: tagRange.file,
-    start: {line: tagRange.end.line, column: tagRange.end.column},
-    end: {line: tagRange.end.line, column: tagRange.end.column}
-  };
-  return {replacementText, range};
 }
 
 registry.register(new IronFlexLayoutClasses());

--- a/src/rules.ts
+++ b/src/rules.ts
@@ -27,5 +27,5 @@ import './polymer/databind-with-unknown-property';
 import './polymer/element-before-dom-module';
 import './polymer/set-unknown-attribute';
 import './polymer/unbalanced-delimiters';
-import './polymer/iron-flex-layout-import';
-import './polymer/iron-flex-layout-classes';
+
+import './polymer/elements/rules';

--- a/src/test/polymer/iron-flex-layout-import_test.ts
+++ b/src/test/polymer/iron-flex-layout-import_test.ts
@@ -42,7 +42,8 @@ suite(ruleId, () => {
   });
 
   test('warns when deprecated files are used with the right messages', async() => {
-    const warnings = await linter.lint([`${ruleId}/deprecated-files-before-fixes.html`]);
+    const warnings =
+        await linter.lint([`${ruleId}/deprecated-files-before-fixes.html`]);
     assert.deepEqual(warningPrinter.prettyPrint(warnings), [
       `
 <link rel="import" href="./iron-flex-layout/classes/iron-flex-layout.html">
@@ -62,32 +63,41 @@ Run the lint rule \`iron-flex-layout-classes\` with \`--fix\` to include the req
     ]);
   });
 
-  test('applies automatic-safe fixes when deprecated files are used', async() => {
-    const warnings = await linter.lint([`${ruleId}/deprecated-files-before-fixes.html`]);
-    const edits = warnings.filter((w) => w.fix).map((w) => w.fix!);
-    const loader = makeParseLoader(analyzer);
-    const result = await applyEdits(edits, loader);
-    assert.deepEqual(
-        result.editedFiles.get(`${ruleId}/deprecated-files-before-fixes.html`),
-        (await loader(`${ruleId}/deprecated-files-after-fixes.html`)).contents);
-  });
+  test(
+      'applies automatic-safe fixes when deprecated files are used',
+      async() => {
+        const warnings =
+            await linter.lint([`${ruleId}/deprecated-files-before-fixes.html`]);
+        const edits = warnings.filter((w) => w.fix).map((w) => w.fix!);
+        const loader = makeParseLoader(analyzer);
+        const result = await applyEdits(edits, loader);
+        assert.deepEqual(
+            result.editedFiles.get(
+                `${ruleId}/deprecated-files-before-fixes.html`),
+            (await loader(`${ruleId}/deprecated-files-after-fixes.html`))
+                .contents);
+      });
 
-  test('warns when iron-flex-layout modules are used but not imported', async() => {
-    const warnings = await linter.lint([`${ruleId}/forgot-import-before-fixes.html`]);
-    assert.deepEqual(warningPrinter.prettyPrint(warnings), [
-      `
+  test(
+      'warns when iron-flex-layout modules are used but not imported',
+      async() => {
+        const warnings =
+            await linter.lint([`${ruleId}/forgot-import-before-fixes.html`]);
+        assert.deepEqual(warningPrinter.prettyPrint(warnings), [
+          `
     <style include="iron-flex"></style>
                    ~~~~~~~~~~~`,
-    ]);
+        ]);
 
-    assert.deepEqual(warnings.map((w) => w.message), [
-      `iron-flex-layout style modules are used but not imported.
+        assert.deepEqual(warnings.map((w) => w.message), [
+          `iron-flex-layout style modules are used but not imported.
 Import iron-flex-layout/iron-flex-layout-classes.html`,
-    ]);
-  });
+        ]);
+      });
 
   test('adds missing import by inferring the base path', async() => {
-    const warnings = await linter.lint([`${ruleId}/forgot-import-before-fixes.html`]);
+    const warnings =
+        await linter.lint([`${ruleId}/forgot-import-before-fixes.html`]);
     const edits = warnings.filter((w) => w.fix).map((w) => w.fix!);
     const loader = makeParseLoader(analyzer);
     const result = await applyEdits(edits, loader);
@@ -97,17 +107,21 @@ Import iron-flex-layout/iron-flex-layout-classes.html`,
   });
 
   test('adds missing import by defaulting the base path', async() => {
-    const warnings = await linter.lint([`${ruleId}/forgot-import-no-imports-before-fixes.html`]);
+    const warnings = await linter.lint(
+        [`${ruleId}/forgot-import-no-imports-before-fixes.html`]);
     const edits = warnings.filter((w) => w.fix).map((w) => w.fix!);
     const loader = makeParseLoader(analyzer);
     const result = await applyEdits(edits, loader);
     assert.deepEqual(
-        result.editedFiles.get(`${ruleId}/forgot-import-no-imports-before-fixes.html`),
-        (await loader(`${ruleId}/forgot-import-no-imports-after-fixes.html`)).contents);
+        result.editedFiles.get(
+            `${ruleId}/forgot-import-no-imports-before-fixes.html`),
+        (await loader(`${ruleId}/forgot-import-no-imports-after-fixes.html`))
+            .contents);
   });
 
   test('warns when iron-flex-layout modules are imported but not used', async() => {
-    const warnings = await linter.lint([`${ruleId}/unnecessary-import-before-fixes.html`]);
+    const warnings =
+        await linter.lint([`${ruleId}/unnecessary-import-before-fixes.html`]);
     assert.deepEqual(warningPrinter.prettyPrint(warnings), [
       `
 <link rel="import" href="iron-flex-layout/iron-flex-layout-classes.html">
@@ -115,17 +129,20 @@ Import iron-flex-layout/iron-flex-layout-classes.html`,
     ]);
 
     assert.deepEqual(warnings.map((w) => w.message), [
-      `This import defines style modules that are not being used. Remove it.`,
+      `This import defines style modules that are not being used. It can be removed.`,
     ]);
   });
 
   test('removes unnecessary import', async() => {
-    const warnings = await linter.lint([`${ruleId}/unnecessary-import-before-fixes.html`]);
+    const warnings =
+        await linter.lint([`${ruleId}/unnecessary-import-before-fixes.html`]);
     const edits = warnings.filter((w) => w.fix).map((w) => w.fix!);
     const loader = makeParseLoader(analyzer);
     const result = await applyEdits(edits, loader);
     assert.deepEqual(
-        result.editedFiles.get(`${ruleId}/unnecessary-import-before-fixes.html`),
-        (await loader(`${ruleId}/unnecessary-import-after-fixes.html`)).contents);
+        result.editedFiles.get(
+            `${ruleId}/unnecessary-import-before-fixes.html`),
+        (await loader(`${ruleId}/unnecessary-import-after-fixes.html`))
+            .contents);
   });
 });

--- a/src/test/polymer/iron-flex-layout-import_test.ts
+++ b/src/test/polymer/iron-flex-layout-import_test.ts
@@ -41,8 +41,8 @@ suite(ruleId, () => {
     assert.deepEqual(warnings, []);
   });
 
-  test('warns for the proper cases and with the right messages', async() => {
-    const warnings = await linter.lint([`${ruleId}/before-fixes.html`]);
+  test('warns when deprecated files are used with the right messages', async() => {
+    const warnings = await linter.lint([`${ruleId}/deprecated-files-before-fixes.html`]);
     assert.deepEqual(warningPrinter.prettyPrint(warnings), [
       `
 <link rel="import" href="./iron-flex-layout/classes/iron-flex-layout.html">
@@ -62,13 +62,70 @@ Run the lint rule \`iron-flex-layout-classes\` with \`--fix\` to include the req
     ]);
   });
 
-  test('applies automatic-safe fixes', async() => {
-    const warnings = await linter.lint([`${ruleId}/before-fixes.html`]);
+  test('applies automatic-safe fixes when deprecated files are used', async() => {
+    const warnings = await linter.lint([`${ruleId}/deprecated-files-before-fixes.html`]);
     const edits = warnings.filter((w) => w.fix).map((w) => w.fix!);
     const loader = makeParseLoader(analyzer);
     const result = await applyEdits(edits, loader);
     assert.deepEqual(
-        result.editedFiles.get(`${ruleId}/before-fixes.html`),
-        (await loader(`${ruleId}/after-fixes.html`)).contents);
+        result.editedFiles.get(`${ruleId}/deprecated-files-before-fixes.html`),
+        (await loader(`${ruleId}/deprecated-files-after-fixes.html`)).contents);
+  });
+
+  test('warns when iron-flex-layout modules are used but not imported', async() => {
+    const warnings = await linter.lint([`${ruleId}/forgot-import-before-fixes.html`]);
+    assert.deepEqual(warningPrinter.prettyPrint(warnings), [
+      `
+    <style include="iron-flex"></style>
+                   ~~~~~~~~~~~`,
+    ]);
+
+    assert.deepEqual(warnings.map((w) => w.message), [
+      `iron-flex-layout style modules are used but not imported.
+Import iron-flex-layout/iron-flex-layout-classes.html`,
+    ]);
+  });
+
+  test('adds missing import by inferring the base path', async() => {
+    const warnings = await linter.lint([`${ruleId}/forgot-import-before-fixes.html`]);
+    const edits = warnings.filter((w) => w.fix).map((w) => w.fix!);
+    const loader = makeParseLoader(analyzer);
+    const result = await applyEdits(edits, loader);
+    assert.deepEqual(
+        result.editedFiles.get(`${ruleId}/forgot-import-before-fixes.html`),
+        (await loader(`${ruleId}/forgot-import-after-fixes.html`)).contents);
+  });
+
+  test('adds missing import by defaulting the base path', async() => {
+    const warnings = await linter.lint([`${ruleId}/forgot-import-no-imports-before-fixes.html`]);
+    const edits = warnings.filter((w) => w.fix).map((w) => w.fix!);
+    const loader = makeParseLoader(analyzer);
+    const result = await applyEdits(edits, loader);
+    assert.deepEqual(
+        result.editedFiles.get(`${ruleId}/forgot-import-no-imports-before-fixes.html`),
+        (await loader(`${ruleId}/forgot-import-no-imports-after-fixes.html`)).contents);
+  });
+
+  test('warns when iron-flex-layout modules are imported but not used', async() => {
+    const warnings = await linter.lint([`${ruleId}/unnecessary-import-before-fixes.html`]);
+    assert.deepEqual(warningPrinter.prettyPrint(warnings), [
+      `
+<link rel="import" href="iron-flex-layout/iron-flex-layout-classes.html">
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~`,
+    ]);
+
+    assert.deepEqual(warnings.map((w) => w.message), [
+      `This import defines style modules that are not being used. Remove it.`,
+    ]);
+  });
+
+  test('removes unnecessary import', async() => {
+    const warnings = await linter.lint([`${ruleId}/unnecessary-import-before-fixes.html`]);
+    const edits = warnings.filter((w) => w.fix).map((w) => w.fix!);
+    const loader = makeParseLoader(analyzer);
+    const result = await applyEdits(edits, loader);
+    assert.deepEqual(
+        result.editedFiles.get(`${ruleId}/unnecessary-import-before-fixes.html`),
+        (await loader(`${ruleId}/unnecessary-import-after-fixes.html`)).contents);
   });
 });

--- a/test/iron-flex-layout-import/after-fixes.html
+++ b/test/iron-flex-layout-import/after-fixes.html
@@ -1,1 +1,0 @@
-<link rel="import" href="./iron-flex-layout/iron-flex-layout-classes.html">

--- a/test/iron-flex-layout-import/before-fixes.html
+++ b/test/iron-flex-layout-import/before-fixes.html
@@ -1,2 +1,0 @@
-<link rel="import" href="./iron-flex-layout/classes/iron-flex-layout.html">
-<link rel="import" href="./iron-flex-layout/classes/iron-shadow-flex-layout.html">

--- a/test/iron-flex-layout-import/deprecated-files-after-fixes.html
+++ b/test/iron-flex-layout-import/deprecated-files-after-fixes.html
@@ -1,0 +1,12 @@
+<link rel="import" href="./iron-flex-layout/iron-flex-layout-classes.html">
+<dom-module id="foo-bar">
+  <template>
+    <style include="iron-flex"></style>
+    <div class="flex"></div>
+  </template>
+  <script>
+    Polymer({
+      is: 'foo-bar'
+    });
+  </script>
+</dom-module>

--- a/test/iron-flex-layout-import/deprecated-files-before-fixes.html
+++ b/test/iron-flex-layout-import/deprecated-files-before-fixes.html
@@ -1,0 +1,13 @@
+<link rel="import" href="./iron-flex-layout/classes/iron-flex-layout.html">
+<link rel="import" href="./iron-flex-layout/classes/iron-shadow-flex-layout.html">
+<dom-module id="foo-bar">
+  <template>
+    <style include="iron-flex"></style>
+    <div class="flex"></div>
+  </template>
+  <script>
+    Polymer({
+      is: 'foo-bar'
+    });
+  </script>
+</dom-module>

--- a/test/iron-flex-layout-import/forgot-import-after-fixes.html
+++ b/test/iron-flex-layout-import/forgot-import-after-fixes.html
@@ -1,0 +1,7 @@
+<link rel="import" href="iron-flex-layout/iron-flex-layout.html">
+<link rel="import" href="iron-flex-layout/iron-flex-layout-classes.html">
+<dom-module id="foo-bar">
+  <template>
+    <style include="iron-flex"></style>
+  </template>
+</dom-module>

--- a/test/iron-flex-layout-import/forgot-import-before-fixes.html
+++ b/test/iron-flex-layout-import/forgot-import-before-fixes.html
@@ -1,0 +1,6 @@
+<link rel="import" href="iron-flex-layout/iron-flex-layout.html">
+<dom-module id="foo-bar">
+  <template>
+    <style include="iron-flex"></style>
+  </template>
+</dom-module>

--- a/test/iron-flex-layout-import/forgot-import-no-imports-after-fixes.html
+++ b/test/iron-flex-layout-import/forgot-import-no-imports-after-fixes.html
@@ -1,0 +1,6 @@
+<link rel="import" href="./iron-flex-layout/iron-flex-layout-classes.html">
+<dom-module id="foo-bar">
+  <template>
+    <style include="iron-flex"></style>
+  </template>
+</dom-module>

--- a/test/iron-flex-layout-import/forgot-import-no-imports-before-fixes.html
+++ b/test/iron-flex-layout-import/forgot-import-no-imports-before-fixes.html
@@ -1,0 +1,5 @@
+<dom-module id="foo-bar">
+  <template>
+    <style include="iron-flex"></style>
+  </template>
+</dom-module>

--- a/test/iron-flex-layout-import/unnecessary-import-after-fixes.html
+++ b/test/iron-flex-layout-import/unnecessary-import-after-fixes.html
@@ -1,0 +1,6 @@
+<link rel="import" href="iron-flex-layout/iron-flex-layout.html">
+<dom-module id="foo-bar">
+  <template>
+    <div>Hello!</div>
+  </template>
+</dom-module>

--- a/test/iron-flex-layout-import/unnecessary-import-before-fixes.html
+++ b/test/iron-flex-layout-import/unnecessary-import-before-fixes.html
@@ -1,0 +1,7 @@
+<link rel="import" href="iron-flex-layout/iron-flex-layout.html">
+<link rel="import" href="iron-flex-layout/iron-flex-layout-classes.html">
+<dom-module id="foo-bar">
+  <template>
+    <div>Hello!</div>
+  </template>
+</dom-module>


### PR DESCRIPTION
<!--
  Thanks for the PR!

  If this change has a user visible change (including
  bug fixes, new features, etc) please describe the change in
  CHANGELOG.md.

  If the change is an entirely package-internal reshuffling/refactoring
  should the change not be described in the CHANGELOG.

  Consider also updating the README.

  More info: http://keepachangelog.com/en/0.3.0/
 -->

 - [x] CHANGELOG.md has been updated

Update `iron-flex-layout-import` rule to understand if the import is actually needed or not.
This is done by searching at the style module including one the iron-flex-layout modules.

If the file is imported but not needed, we can remove it.

If the file is needed but not imported, we can add it (inferring the base path by looking at polymer-like imports, aka the ones with href ending with `iron-*/iron-*.html` (or `paper-` or `app-`). If such imports are not present, we currently fallback to the current directory as base path (which might cause a 404 on the app). The work done in https://github.com/Polymer/polymer-linter/pull/122 might be used here to require user action in this fallback condition.


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/polymer/polymer-linter/123)
<!-- Reviewable:end -->
