### PR TITLE
Use weak maps for fast and cheap caching of lint results.

### DIFF
--- a/src/linter.ts
+++ b/src/linter.ts
@@ -65,7 +65,7 @@ export class Linter {
       }
       for (const rule of this._rules) {
         try {
-          warnings.push(...await rule.check(document));
+          warnings.push(...await rule.cachedCheck(document));
         } catch (e) {
           warnings.push(this._getWarningFromError(
               document.parsedDocument,

--- a/src/rule.ts
+++ b/src/rule.ts
@@ -29,10 +29,29 @@ export abstract class Rule {
    */
   abstract description: string;
 
+  protected cache = new WeakMap<Document, Promise<ReadonlyArray<Warning>>>();
+
+  /**
+   * Finds all warnings in the given document.
+   *
+   * If this rule has checked this document before, just looks up the result
+   * in our cache. Because Documents are immutable and are guaranteed to be
+   * different if any of their contents are different, this caching is safe.
+   */
+  cachedCheck(document: Document): Promise<ReadonlyArray<Warning>> {
+    const cacheResult = this.cache.get(document);
+    if (cacheResult) {
+      return cacheResult;
+    }
+    const result = this.check(document);
+    this.cache.set(document, result);
+    return result;
+  }
+
   /**
    * Finds all warnings in the given document.
    */
-  abstract check(document: Document): Promise<Warning[]>;
+  protected abstract check(document: Document): Promise<Warning[]>;
 }
 
 /**


### PR DESCRIPTION
<!--
  Thanks for the PR!

  If this change has a user visible change (including
  bug fixes, new features, etc) please describe the change in
  CHANGELOG.md.

  If the change is an entirely package-internal reshuffling/refactoring
  should the change not be described in the CHANGELOG.

  Consider also updating the README.

  More info: http://keepachangelog.com/en/0.3.0/
 -->

 - [x] CHANGELOG.md not updated, purely internal change.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/polymer/polymer-linter/131)
<!-- Reviewable:end -->
