### PR TITLE
Have a clearer first line of descriptions.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-<!-- ## Unreleased -->
+## Unreleased
+- Improve the wording on the content-to-slot-declaration's unsafe edit action.
 
 ## [2.2.1] - 2017-11-16
 - The array of warnings returned by `Linter#lint()` and `Linter#lintPackage()` now also has a non-enumerable `analysis` property, which refers to the immutable `Analysis` used to generate the lint results.

--- a/src/polymer/content-to-slot-declarations.ts
+++ b/src/polymer/content-to-slot-declarations.ts
@@ -80,10 +80,11 @@ class ContentToSlotDeclarations extends HtmlRule {
               kind: 'edit',
               code: 'content-with-select',
               description: stripIndentation(`
-                Convert this <content> to a <slot>.
+                Convert to a <slot> element. This is a breaking change!
 
                 This changes the API of this element because the \`select\`
-                attribute will become a slot name. Use the content-to-slot-usages lint pass to convert usages of the
+                attribute will become a slot name. Use the
+                content-to-slot-usages lint pass to convert usages of the
                 element to conform to the new API.
               `),
               edit


### PR DESCRIPTION
In the IDE, we can only display one short line of text for an edit action, so that first line has to be very clear.

 - [x] CHANGELOG.md updated

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/polymer/polymer-linter/135)
<!-- Reviewable:end -->
