### PR TITLE
Fix: Better guess for label slot

### DIFF
--- a/src/polymer/content-to-slot-usages.ts
+++ b/src/polymer/content-to-slot-usages.ts
@@ -250,6 +250,7 @@ addPredicate('paper-input-container', [
   {selector: '[prefix]', slot: 'prefix'},
   {selector: '[suffix]', slot: 'suffix'},
   {selector: '[add-on]', slot: 'add-on'},
+  {selector: 'label', slot: 'label'},
   {selector: '*', slot: 'input'},
 ]);
 


### PR DESCRIPTION
<!--
  Thanks for the PR!

  If this change has a user visible change (including
  bug fixes, new features, etc) please describe the change in
  CHANGELOG.md.

  If the change is an entirely package-internal reshuffling/refactoring
  should the change not be described in the CHANGELOG.

  Consider also updating the README.

  More info: http://keepachangelog.com/en/0.3.0/
 -->

 - [ ] CHANGELOG.md has been updated

I noticed that `paper-input-container`s with `label` are getting marked with `slot="input"`. The previous selector was for "input" and "label" (`:not([add-on]):not([prefix]):not([suffix])`)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/polymer/polymer-linter/157)
<!-- Reviewable:end -->
