### PR TITLE
New: Warn deprecated Shadow DOM selectors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
-- Add a rule to detect `Polymer.dom` usages where native methods/properties may
-  now be used
+### New Lint Rules
+- `dom-calls-to-native`: Warns when `Polymer.dom` is used where native methods/properties may
+- `deprecated-shadow-dom-selectors`: Warns when deprecated Shadow DOM selectors are used. (`/deep/`, `>>>`, and `::shadow`)
 
 ## [3.0.0-pre.1] - 2017-12-21
 - [BREAKING] Return an object with `warnings` and `analysis` properties
@@ -76,7 +77,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - polymer-lint is now at feature parity with [polylint](https://github.com/PolymerLabs/polylint), and is ready to replace it!
 
 ### New Lint Rules
-- `databind-with-unknown-property` - Warns when a polymer element's databindings use properties that aren't declared on that element.
+- `databind-with-unknown-property`: Warns when a polymer element's databindings use properties that aren't declared on that element.
 - `element-before-dom-module`: Warns when a Polymer element is defined before its `<dom-module>` exists in the DOM.
 - `databinding-calls-must-be-functions`: Computed functions, observers, and calls in databinding expressions must be either methods on the element or properties with types that could be function types.
 - `call-super-in-callbacks`: Warns when a Polymer 2.0 element does not call super() in callbacks that require it, like `connectedCallback`.

--- a/src/collections.ts
+++ b/src/collections.ts
@@ -25,15 +25,16 @@ registry.register(
       'content-to-slot-usages',
       'databind-with-unknown-property',
       'databinding-calls-must-be-functions',
+      'deprecated-css-custom-property-syntax',
+      'deprecated-shadow-dom-selectors',
+      'dom-calls-to-native',
       'dom-module-invalid-attrs',
       'element-before-dom-module',
+      'paper-toolbar-v1-to-v2',
       'set-unknown-attribute',
       'style-into-template',
       'unbalanced-polymer-delimiters',
       'undefined-elements',
-      'deprecated-css-custom-property-syntax',
-      'paper-toolbar-v1-to-v2',
-      'dom-calls-to-native',
     ]));
 
 registry.register(new RuleCollection(
@@ -47,14 +48,15 @@ Will warn about use of deprecated Polymer 1.x features or brand new features in 
       'content-to-slot-usages',
       'databinding-calls-must-be-functions',
       'databind-with-unknown-property',
+      'deprecated-css-custom-property-syntax',
+      'deprecated-shadow-dom-selectors',
       'dom-module-invalid-attrs',
       'element-before-dom-module',
+      'paper-toolbar-v1-to-v2',
       'set-unknown-attribute',
       'style-into-template',
       'unbalanced-polymer-delimiters',
       'undefined-elements',
-      'deprecated-css-custom-property-syntax',
-      'paper-toolbar-v1-to-v2',
     ]));
 
 registry.register(new RuleCollection(

--- a/src/css/deprecated-css-custom-property-syntax.ts
+++ b/src/css/deprecated-css-custom-property-syntax.ts
@@ -76,7 +76,7 @@ class DeprecatedCustomPropertySyntax extends CssRule {
   private addVarSyntaxWarnings(
       node: shady.Node, parsedDocument: ParsedCssDocument,
       warnings: Warning[]): any {
-    if (node.type === 'expression') {
+    if (node.type === shady.nodeType.expression) {
       const match = node.text.match(
           /var\s*\(\s*--[a-zA-Z0-9_-]+\s*,\s*(--[a-zA-Z0-9_-]+)\s*\)/);
       if (match) {

--- a/src/css/deprecated-shadow-dom-selectors.ts
+++ b/src/css/deprecated-shadow-dom-selectors.ts
@@ -1,0 +1,57 @@
+/**
+ * @license
+ * Copyright (c) 2018 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at
+ * http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at
+ * http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+import {Document, ParsedCssDocument, Severity, Warning} from 'polymer-analyzer';
+import * as shady from 'shady-css-parser';
+
+import {CssRule} from '../css/rule';
+import {registry} from '../registry';
+import {stripIndentation} from '../util';
+
+class DeprecatedShadowPiercingCombinators extends CssRule {
+  code = 'deprecated-shadow-dom-selectors';
+  description = stripIndentation(`
+      Warns when using deprecated Shadow DOM selectors.
+  `);
+
+  async checkDocument(parsedDocument: ParsedCssDocument, _document: Document) {
+    const warnings: Warning[] = [];
+  
+    for (const node of parsedDocument) {
+      if (node.type === shady.nodeType.ruleset) {
+        const deprecatedCombinatorsRegex = /(\/deep\/|>>>|::shadow)/g;
+        let match: RegExpExecArray | null;
+        
+        while ((match = deprecatedCombinatorsRegex.exec(node.selector)) !== null) {
+          const combinatorOffset = match.index!;
+          const start = node.range.start + combinatorOffset;
+          const end = start + match[0].length;
+          const sourceRange =
+            parsedDocument.sourceRangeForShadyRange({ start, end });
+          warnings.push(new Warning({
+            code: 'deprecated-combinator',
+            severity: Severity.WARNING, parsedDocument, sourceRange,
+            message:
+                'The /deep/ (>>>) combinator and ::shadow pseudo-element ' +
+                'have been deprecated.',
+          }));
+        }
+      }
+    }
+
+    return warnings;
+  }
+}
+
+registry.register(new DeprecatedShadowPiercingCombinators());

--- a/src/css/deprecated-shadow-dom-selectors.ts
+++ b/src/css/deprecated-shadow-dom-selectors.ts
@@ -27,12 +27,12 @@ class DeprecatedShadowPiercingCombinators extends CssRule {
 
   async checkDocument(parsedDocument: ParsedCssDocument, _document: Document) {
     const warnings: Warning[] = [];
-  
+
     for (const node of parsedDocument) {
       if (node.type === shady.nodeType.ruleset) {
         const deprecatedCombinatorsRegex = /(\/deep\/|>>>|::shadow)/g;
         let match: RegExpExecArray | null;
-        
+
         while ((match = deprecatedCombinatorsRegex.exec(node.selector)) !== null) {
           const combinatorOffset = match.index!;
           const start = node.range.start + combinatorOffset;
@@ -40,7 +40,7 @@ class DeprecatedShadowPiercingCombinators extends CssRule {
           const sourceRange =
             parsedDocument.sourceRangeForShadyRange({ start, end });
           warnings.push(new Warning({
-            code: 'deprecated-combinator',
+            code: 'deprecated-shadow-dom-selectors',
             severity: Severity.WARNING, parsedDocument, sourceRange,
             message:
                 'The /deep/ (>>>) combinator and ::shadow pseudo-element ' +

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -57,7 +57,6 @@ export class LintRegistry {
       ruleCodes: string[], alreadyExpanded: Set<string>,
       results: Set<Rule>): void {
     ruleCodes = ruleCodes.filter((p) => !alreadyExpanded.has(p));
-
     for (const code of ruleCodes) {
       alreadyExpanded.add(code);
       const ruleOrCollection = this._all.get(code);

--- a/src/rules.ts
+++ b/src/rules.ts
@@ -13,6 +13,7 @@
  */
 
 import './css/deprecated-css-custom-property-syntax';
+import './css/deprecated-shadow-dom-selectors';
 
 import './html/dom-module-name-or-is';
 import './html/move-style-into-template';

--- a/src/test/css/deprecated-shadow-dom-selectors_test.ts
+++ b/src/test/css/deprecated-shadow-dom-selectors_test.ts
@@ -1,0 +1,72 @@
+/**
+ * @license
+ * Copyright (c) 2018 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at
+ * http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at
+ * http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+import {assert} from 'chai';
+import * as path from 'path';
+import {Analyzer} from 'polymer-analyzer';
+
+import {Linter} from '../../linter';
+import {registry} from '../../registry';
+import {WarningPrettyPrinter} from '../util';
+
+const fixtures_dir = path.join(__dirname, '..', '..', '..', 'test');
+const ruleId = `deprecated-shadow-dom-selectors`;
+
+suite(ruleId, () => {
+  let analyzer: Analyzer;
+  let warningPrinter: WarningPrettyPrinter;
+  let linter: Linter;
+
+  setup(() => {
+    analyzer = Analyzer.createForDirectory(fixtures_dir);
+    warningPrinter = new WarningPrettyPrinter();
+    linter = new Linter(registry.getRules([ruleId]), analyzer);
+  });
+
+  test('works in the trivial case', async() => {
+    const {warnings} = await linter.lint([]);
+    assert.deepEqual([...warnings], []);
+  });
+
+  test('gives no warnings for a perfectly fine file', async() => {
+    const {warnings} =
+        await linter.lint(['perfectly-fine/polymer-element.html']);
+    assert.deepEqual([...warnings], []);
+  });
+
+  test('warns for the proper cases and with the right messages', async() => {
+    const {warnings} = await linter.lint([`${ruleId}/${ruleId}.html`]);
+    assert.deepEqual(warningPrinter.prettyPrint(warnings), [
+      `
+  x-tabs /deep/ x-panel {
+         ~~~~~~`,
+      `
+  x-tabs >>> x-panel {
+         ~~~`,
+      `
+    x-tabs::shadow x-panel::shadow h2 {
+          ~~~~~~~~`,
+      `
+    x-tabs::shadow x-panel::shadow h2 {
+                          ~~~~~~~~`,
+    ]);
+
+    assert.deepEqual(warnings.map((w) => w.message), [
+      `The /deep/ (>>>) combinator and ::shadow pseudo-element have been deprecated.`,
+      `The /deep/ (>>>) combinator and ::shadow pseudo-element have been deprecated.`,
+      `The /deep/ (>>>) combinator and ::shadow pseudo-element have been deprecated.`,
+      `The /deep/ (>>>) combinator and ::shadow pseudo-element have been deprecated.`,
+    ]);
+  });
+});

--- a/src/test/polymer/dom-calls-to-native.ts
+++ b/src/test/polymer/dom-calls-to-native.ts
@@ -22,7 +22,7 @@ import {WarningPrettyPrinter} from '../util';
 
 const fixtures_dir = path.join(__dirname, '..', '..', '..', 'test');
 
-suite.only('dom-calls-to-native', () => {
+suite('dom-calls-to-native', () => {
   let analyzer: Analyzer;
   let warningPrinter: WarningPrettyPrinter;
   let linter: Linter;

--- a/test/deprecated-shadow-dom-selectors/deprecated-shadow-dom-selectors.html
+++ b/test/deprecated-shadow-dom-selectors/deprecated-shadow-dom-selectors.html
@@ -1,0 +1,17 @@
+<style>
+  x-tabs /deep/ x-panel {
+    color: #F00;
+  }
+
+  x-tabs >>> x-panel {
+    color: #0F0;
+  }
+</style>
+<template>
+  <style>
+    x-tabs::shadow x-panel::shadow h2 {
+      color: #00F;
+    }
+  </style>
+</template>
+  


### PR DESCRIPTION
<!--
  Thanks for the PR!

  If this change has a user visible change (including
  bug fixes, new features, etc) please describe the change in
  CHANGELOG.md.

  If the change is an entirely package-internal reshuffling/refactoring
  should the change not be described in the CHANGELOG.

  Consider also updating the README.

  More info: http://keepachangelog.com/en/0.3.0/
 -->

 - [x] CHANGELOG.md has been updated

Warns about usages of `/deep/`, `>>>`, and `::shadow`

Fixes #6 

/cc @rictic 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/polymer/polymer-linter/158)
<!-- Reviewable:end -->
