### PR TITLE
Fix: Don't apply fix for selector after ::slotted selector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Make `dom-module-invalid-attrs` rule fixable for cases where only `is` or `name` exist, and both if they use the same values.
 - `create-element-extension`: Warns when using the second parameter of `createElement` for element extension using the `is` attribute.
 
+### Fixes
+- `content-selector-to-slotted`: Don't attempt to fix usages where a selector would come after `::slotted`
+
 ## [3.0.0-pre.2] - 2018-02-16
 ### New Lint Rules
 - `dom-calls-to-native`: Warns when `Polymer.dom` is used where native methods/properties may

--- a/src/css/content-selector-to-slotted.ts
+++ b/src/css/content-selector-to-slotted.ts
@@ -42,7 +42,7 @@ class ContentToSlottedUsages extends CssRule {
 
           let fix: ReadonlyArray<Replacement>|undefined;
           // Safe fix only if we know the selector is immediate descendant
-          const safeFixRegex = /::content\s*>\s*([^\s]+)/;
+          const safeFixRegex = /::content\s*>\s*([^\s]+)$/;
           const descendantSelectorMatch = node.selector.match(safeFixRegex);
           if (descendantSelectorMatch !== null) {
             const descendantSelectorIndex =

--- a/src/test/css/content-selector-to-slotted_test.ts
+++ b/src/test/css/content-selector-to-slotted_test.ts
@@ -64,11 +64,15 @@ suite(ruleId, () => {
     ::content > [top-item] {
     ~~~~~~~~~`,
       `
+    ::content > [top-item] [child] {
+    ~~~~~~~~~`,
+      `
     ::content * {
     ~~~~~~~~~`,
     ]);
 
     assert.deepEqual(warnings.map((w) => w.message), [
+      `The ::content pseudo-element has been deprecated in favor of the ::slotted psuedo-element in ShadowDOM v1.`,
       `The ::content pseudo-element has been deprecated in favor of the ::slotted psuedo-element in ShadowDOM v1.`,
       `The ::content pseudo-element has been deprecated in favor of the ::slotted psuedo-element in ShadowDOM v1.`,
       `The ::content pseudo-element has been deprecated in favor of the ::slotted psuedo-element in ShadowDOM v1.`,

--- a/test/content-selector-to-slotted/after-fixes.html
+++ b/test/content-selector-to-slotted/after-fixes.html
@@ -14,6 +14,9 @@
     :host ::slotted([top-item]) {
       color: #F00;
     }
+    ::content > [top-item] [child] {
+      color: #0F0;
+    }
     ::content top-item {
       color: #0F0;
     }

--- a/test/content-selector-to-slotted/before-fixes.html
+++ b/test/content-selector-to-slotted/before-fixes.html
@@ -14,6 +14,9 @@
     :host ::content > [top-item] {
       color: #F00;
     }
+    ::content > [top-item] [child] {
+      color: #0F0;
+    }
     ::content top-item {
       color: #0F0;
     }

--- a/test/content-selector-to-slotted/content-selector-to-slotted.html
+++ b/test/content-selector-to-slotted/content-selector-to-slotted.html
@@ -17,6 +17,9 @@
     ::content > [top-item] {
       color: #0F0;
     }
+    ::content > [top-item] [child] {
+      color: #0F0;
+    }
     ::content * {
       color: #00F;
     }


### PR DESCRIPTION
<!--
  Thanks for the PR!

  If this change has a user visible change (including
  bug fixes, new features, etc) please describe the change in
  CHANGELOG.md.

  If the change is an entirely package-internal reshuffling/refactoring
  should the change not be described in the CHANGELOG.

  Consider also updating the README.

  More info: http://keepachangelog.com/en/0.3.0/
 -->

 - [x] CHANGELOG.md has been updated

/cc @rictic 

I was previously not checking a case where a selector would come after the `::slotted` selector, which we can not fix safely.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/polymer/polymer-linter/169)
<!-- Reviewable:end -->
